### PR TITLE
Register Http4sHandler as late as possible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Cache Coursier
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/coursier
-        key: ${{ runner.os }}-sbt-cache-${{ hashFiles('**/build.sbt') }}
-    - name: Cache Sbt
-      uses: actions/cache@v1
-      with:
-        path: ~/.sbt
-        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+      uses: coursier/cache-action@v3
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ release.sbt
 .metals
 .bloop
 out
+.bsp

--- a/client/src/main/scala/org/http4s/netty/client/Http4sChannelPoolMap.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sChannelPoolMap.scala
@@ -22,10 +22,7 @@ import org.http4s.client.RequestKey
 
 import scala.concurrent.duration.Duration
 
-class Http4sChannelPoolMap[F[_]](
-    bootstrap: Bootstrap,
-    config: Http4sChannelPoolMap.Config,
-    handler: Http4sHandler[F])
+class Http4sChannelPoolMap[F[_]](bootstrap: Bootstrap, config: Http4sChannelPoolMap.Config)
     extends AbstractChannelPoolMap[RequestKey, FixedChannelPool] {
   private[this] val logger = org.log4s.getLogger
   private var onConnection: (Channel) => Unit = (_: Channel) => ()
@@ -34,7 +31,7 @@ class Http4sChannelPoolMap[F[_]](
   override def newPool(key: RequestKey): FixedChannelPool =
     new MyFixedChannelPool(
       bootstrap,
-      new WrappedChannelPoolHandler(key, config, handler),
+      new WrappedChannelPoolHandler(key, config),
       config.maxConnections,
       key)
 
@@ -61,8 +58,7 @@ class Http4sChannelPoolMap[F[_]](
 
   class WrappedChannelPoolHandler(
       key: RequestKey,
-      config: Http4sChannelPoolMap.Config,
-      handler: Http4sHandler[F]
+      config: Http4sChannelPoolMap.Config
   ) extends AbstractChannelPoolHandler {
 
     override def channelAcquired(ch: Channel): Unit = {
@@ -110,7 +106,7 @@ class Http4sChannelPoolMap[F[_]](
           .addLast(
             "timeout",
             new IdleStateHandler(0, 0, config.idleTimeout.length, config.idleTimeout.unit))
-      pipeline.addLast("http4s", handler)
+      //pipeline.addLast("http4s", handler)
     }
   }
 }

--- a/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
@@ -44,6 +44,8 @@ private[netty] class Http4sHandler[F[_]](cb: Http4sHandler.CB[F])(implicit F: Co
         }.unsafeRunSync()
       case _ =>
         super.channelRead(ctx, msg)
+        ctx.pipeline().remove(this)
+        ()
     }
 
   @SuppressWarnings(Array("deprecation"))

--- a/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
@@ -12,63 +12,59 @@ import io.netty.util.AttributeKey
 import org.http4s.Response
 import org.http4s.netty.NettyModelConversion
 
-private[netty] class Http4sHandler[F[_]](implicit F: ConcurrentEffect[F])
+private[netty] class Http4sHandler[F[_]](cb: Http4sHandler.CB[F])(implicit F: ConcurrentEffect[F])
     extends ChannelInboundHandlerAdapter {
-  type CB = (Either[Throwable, Resource[F, Response[F]]]) => Unit
+
+  val POOL_KEY: AttributeKey[SimpleChannelPool] =
+    AttributeKey.valueOf("io.netty.channel.pool.SimpleChannelPool")
 
   private[this] val logger = org.log4s.getLogger
   val modelConversion = new NettyModelConversion[F]()
-  var callback: Option[CB] =
-    None
 
-  def withCallback(cb: CB) =
-    callback = Some(cb)
-
-  override def isSharable: Boolean = true
+  override def isSharable: Boolean = false
 
   override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit =
-    (msg, callback) match {
-      case (h: HttpResponse, Some(cb)) =>
-        val POOL_KEY: AttributeKey[SimpleChannelPool] =
-          AttributeKey.valueOf("io.netty.channel.pool.SimpleChannelPool")
-
+    msg match {
+      case h: HttpResponse =>
         val maybePool = Option(ctx.channel().attr(POOL_KEY).get())
-        F.runAsync(modelConversion.fromNettyResponse(h)) { either =>
+        val responseResourceF = modelConversion.fromNettyResponse(h).map { case (res, cleanup) =>
+          Resource.make(F.pure(res))(_ =>
+            cleanup(ctx.channel()).flatMap(_ =>
+              F.delay(maybePool.foreach { pool =>
+                pool.release(ctx.channel())
+              })))
+        }
+
+        F.runAsync(responseResourceF) { either =>
           IO {
-            cb(either.map { case (res, cleanup) =>
-              Resource.make(F.pure(res))(_ =>
-                cleanup(ctx.channel()).flatMap(_ =>
-                  F.delay(maybePool.foreach { pool =>
-                    pool.release(ctx.channel())
-                  })))
-            })
+            cb(either)
+            ctx.pipeline().remove(this)
+            ()
           }
         }.unsafeRunSync()
-        //reset callback
-        callback = None
       case _ =>
         super.channelRead(ctx, msg)
     }
 
   @SuppressWarnings(Array("deprecation"))
   override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit =
-    (cause, callback) match {
+    cause match {
       // IO exceptions happen all the time, it usually just means that the client has closed the connection before fully
       // sending/receiving the response.
-      case (e: IOException, Some(cb)) =>
+      case e: IOException =>
         logger.trace(e)("Benign IO exception caught in Netty")
-        cb(Left(e))
-        callback = None
-        ctx.channel().close(); ()
-      case (e, Some(cb)) =>
+        onException(ctx, e)
+      case e =>
         logger.error(e)("Exception caught in Netty")
-        cb(Left(e))
-        callback = None
-        ctx.channel().close(); ()
-      case (e, None) =>
-        logger.error(e)("Exception caught in Netty, no callback registered")
-        ctx.channel().close(); ()
+        onException(ctx, e)
     }
+
+  private def onException(ctx: ChannelHandlerContext, e: Throwable): Unit = {
+    cb(Left(e))
+    ctx.channel().close();
+    ctx.pipeline().remove(this)
+    ()
+  }
 
   override def userEventTriggered(ctx: ChannelHandlerContext, evt: scala.Any): Unit =
     evt match {
@@ -77,5 +73,8 @@ private[netty] class Http4sHandler[F[_]](implicit F: ConcurrentEffect[F])
         ctx.channel().close(); ()
       case _ => super.userEventTriggered(ctx, evt)
     }
+}
 
+object Http4sHandler {
+  type CB[F[_]] = (Either[Throwable, Resource[F, Response[F]]]) => Unit
 }

--- a/client/src/test/scala/org/http4s/netty/client/HttpBinTest.scala
+++ b/client/src/test/scala/org/http4s/netty/client/HttpBinTest.scala
@@ -26,7 +26,7 @@ class HttpBinTest extends munit.FunSuite {
       { case io: IO[_] => io.unsafeToFuture() }) :: super.munitValueTransforms
 
   def withClient[A](theTest: (Client[IO]) => IO[A]) = {
-    val builder = NettyClientBuilder[IO].withExecutionContext(munitExecutionContext).resource
+    val builder = NettyClientBuilder[IO].resource
     builder.use(theTest)
   }
 

--- a/server/src/main/scala/org/http4s/netty/server/NettyServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NettyServerBuilder.scala
@@ -38,7 +38,6 @@ final class NettyServerBuilder[F[_]](
     maxChunkSize: Int,
     transport: NettyTransport,
     banner: immutable.Seq[String],
-    executionContext: ExecutionContext,
     nettyChannelOptions: NettyChannelOptions,
     sslConfig: NettyServerBuilder.SslConfig[F],
     websocketsEnabled: Boolean,
@@ -58,7 +57,6 @@ final class NettyServerBuilder[F[_]](
       maxChunkSize: Int = maxChunkSize,
       transport: NettyTransport = transport,
       banner: immutable.Seq[String] = banner,
-      executionContext: ExecutionContext = executionContext,
       nettyChannelOptions: NettyChannelOptions = nettyChannelOptions,
       sslConfig: NettyServerBuilder.SslConfig[F] = sslConfig,
       websocketsEnabled: Boolean = websocketsEnabled,
@@ -75,7 +73,6 @@ final class NettyServerBuilder[F[_]](
       maxChunkSize,
       transport,
       banner,
-      executionContext,
       nettyChannelOptions,
       sslConfig,
       websocketsEnabled,
@@ -98,7 +95,6 @@ final class NettyServerBuilder[F[_]](
     }
 
   def withHttpApp(httpApp: HttpApp[F]): Self = copy(httpApp = httpApp)
-  def withExecutionContext(ec: ExecutionContext): Self = copy(executionContext = ec)
   def bindSocketAddress(address: InetSocketAddress): Self = copy(socketAddress = address)
 
   def bindHttp(port: Int = defaults.HttpPort, host: String = defaults.Host): Self =
@@ -143,6 +139,8 @@ final class NettyServerBuilder[F[_]](
       else socketAddress
     val loop = getEventLoop
     val server = new ServerBootstrap()
+    val executionContext = ExecutionContext.fromExecutorService(loop.eventLoop.next())
+
     val channel = loop
       .configure(server)
       .childHandler(new ChannelInitializer[SocketChannel] {
@@ -249,7 +247,6 @@ object NettyServerBuilder {
       maxChunkSize = 8192,
       transport = NettyTransport.Native,
       banner = org.http4s.server.defaults.Banner,
-      executionContext = ExecutionContext.global,
       nettyChannelOptions = NettyChannelOptions.empty,
       sslConfig = new NettyServerBuilder.NoSsl[F],
       websocketsEnabled = false,

--- a/server/src/test/scala/org/http4s/netty/server/DrainResponseTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/DrainResponseTest.scala
@@ -30,7 +30,6 @@ class DrainResponseTest extends IOSuite {
               .pure[IO]
           }
           .orNotFound)
-      .withExecutionContext(munitExecutionContext)
       .withoutBanner
       .bindAny()
       .resource,

--- a/server/src/test/scala/org/http4s/netty/server/ServerTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/ServerTest.scala
@@ -84,7 +84,7 @@ class JDKServerTest extends ServerTest {
 
 class NettyClientServerTest extends ServerTest {
   val client = resourceFixture(
-    NettyClientBuilder[IO].withExecutionContext(munitExecutionContext).resource,
+    NettyClientBuilder[IO].resource,
     "client"
   )
 }

--- a/server/src/test/scala/org/http4s/netty/server/ServerTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/ServerTest.scala
@@ -11,6 +11,8 @@ import fs2._
 import org.http4s.client.Client
 import org.http4s.client.jdkhttpclient.JdkHttpClient
 import org.http4s.netty.client.NettyClientBuilder
+
+import scala.concurrent.ExecutionContext
 //import org.http4s.server.Server
 
 import scala.concurrent.duration._
@@ -22,7 +24,7 @@ abstract class ServerTest extends IOSuite {
       .withHttpApp(ServerTest.routes)
       .withEventLoopThreads(10)
       .withIdleTimeout(2.seconds)
-      .withExecutionContext(munitExecutionContext)
+      .withExecutionContext(ExecutionContext.global)
       .withoutBanner
       .bindAny()
       .resource,

--- a/server/src/test/scala/org/http4s/netty/server/ServerTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/ServerTest.scala
@@ -12,9 +12,6 @@ import org.http4s.client.Client
 import org.http4s.client.jdkhttpclient.JdkHttpClient
 import org.http4s.netty.client.NettyClientBuilder
 
-import scala.concurrent.ExecutionContext
-//import org.http4s.server.Server
-
 import scala.concurrent.duration._
 
 abstract class ServerTest extends IOSuite {
@@ -24,7 +21,6 @@ abstract class ServerTest extends IOSuite {
       .withHttpApp(ServerTest.routes)
       .withEventLoopThreads(10)
       .withIdleTimeout(2.seconds)
-      .withExecutionContext(ExecutionContext.global)
       .withoutBanner
       .bindAny()
       .resource,

--- a/server/src/test/scala/org/http4s/netty/server/SslServerTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/SslServerTest.scala
@@ -109,7 +109,6 @@ class NettyClientSslServerTest extends SslServerTest() {
   val client = resourceFixture(
     NettyClientBuilder[IO]
       .withSSLContext(sslContext)
-      .withExecutionContext(munitExecutionContext)
       .resource,
     "client"
   )
@@ -123,7 +122,6 @@ class NettyClientMTLSServerTest extends SslServerTest("mTLS") {
   val client = resourceFixture(
     NettyClientBuilder[IO]
       .withSSLContext(sslContext)
-      .withExecutionContext(munitExecutionContext)
       .resource,
     "client"
   )

--- a/server/src/test/scala/org/http4s/netty/server/TestServerPropTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/TestServerPropTest.scala
@@ -17,7 +17,6 @@ class TestServerPropTest extends IOSuite with munit.ScalaCheckSuite {
     NettyServerBuilder[IO]
       .withHttpApp(ServerTest.routes)
       .withIdleTimeout(2.seconds)
-      .withExecutionContext(munitExecutionContext)
       .withoutBanner
       .bindAny()
       .resource,

--- a/server/src/test/scala/org/http4s/netty/server/WebsocketTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/WebsocketTest.scala
@@ -24,7 +24,6 @@ class WebsocketTest extends IOSuite {
   val server = resourceFixture(
     NettyServerBuilder[IO]
       .withHttpApp(routes.orNotFound)
-      .withExecutionContext(munitExecutionContext)
       .withWebsockets
       .withoutBanner
       .bindAny()


### PR DESCRIPTION
Try to stablize the client by moving the registration of the http4s
translation to as late as possible. Having a shared translation layer
seems like it interfers with other requests.