### PR TITLE
Use Entity.Strict and Entity.Empty, optimize Chunk conversions

### DIFF
--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -349,10 +349,7 @@ private[netty] class NettyModelConversion[F[_]](disp: Dispatcher[F])(implicit F:
     response
   }
 
-  private def transferEncoding(
-      headers: Headers,
-      minorIs0: Boolean,
-      response: HttpMessage): Unit = {
+  private def transferEncoding(headers: Headers, minorIs0: Boolean, response: HttpMessage): Unit = {
     headers.foreach(appendSomeToNetty(_, response.headers()))
     val transferEncoding = headers.get[`Transfer-Encoding`]
     headers.get[`Content-Length`] match {


### PR DESCRIPTION
This PR (along with the others I created today) improves performance by around 600-700% on Techempower web benchmarks.

`main` baseline 0.6-b9004ad-SNAPSHOT:
plaintext: Requests/sec: 94268.36
JSON: Requests/sec: 76844.15

This PR + changes from other PRs:
plaintext: Requests/sec: 652202.36
JSON: Requests/sec: 473468.32