### PR TITLE
Fix rendering of request URI

### DIFF
--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -62,7 +62,7 @@ private[netty] class NettyModelConversion[F[_]](disp: Dispatcher[F])(implicit F:
     logger.trace(s"Converting request $request")
     val version = HttpVersion.valueOf(request.httpVersion.toString)
     val method = HttpMethod.valueOf(request.method.name)
-    val uri = request.uri.withoutFragment.copy(authority = None).renderString
+    val uri = request.uri.toOriginForm.renderString
 
     val req =
       if (notAllowedWithBody.contains(request.method))


### PR DESCRIPTION
Example to reproduce the problem:
```
import cats.effect.{IO, IOApp}
import org.http4s.implicits.http4sLiteralsSyntax
import org.http4s.netty.client.NettyClientBuilder
import org.http4s.{Method, Request}

object NettyClientIssue1 extends IOApp.Simple {

  override def run: IO[Unit] =
    NettyClientBuilder[IO]
      .resource
      .use(client =>
        client.expect[String](Request[IO](method = Method.GET, uri = uri"http://example.com/aaa"))
      )
      .void
}
```

`http4s-netty-client` 0.5.1 renders this request as 
```
GET http:/aaa HTTP/1.1
Accept: text/*
Host: example.com
```
(notice the unexpected `http:`)

with this fix it will be rendered as
```
GET /aaa HTTP/1.1
Accept: text/*
Host: example.com
```

The solution is as in [ember-client](https://github.com/http4s/http4s/blob/series/0.23/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala#L96)