### PR TITLE
Fix issue with some headers being rendered twice in non-GET/HEAD requests

### DIFF
--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -65,9 +65,11 @@ private[netty] class NettyModelConversion[F[_]](disp: Dispatcher[F])(implicit F:
     val uri = request.uri.toOriginForm.renderString
 
     val req =
-      if (notAllowedWithBody.contains(request.method))
-        new DefaultFullHttpRequest(version, method, uri)
-      else {
+      if (notAllowedWithBody.contains(request.method)) {
+        val defaultReq = new DefaultFullHttpRequest(version, method, uri)
+        request.headers.foreach(appendSomeToNetty(_, defaultReq.headers()))
+        defaultReq
+      } else {
         val streamedReq = new DefaultStreamedHttpRequest(
           version,
           method,
@@ -81,7 +83,6 @@ private[netty] class NettyModelConversion[F[_]](disp: Dispatcher[F])(implicit F:
         streamedReq
       }
 
-    request.headers.foreach(appendSomeToNetty(_, req.headers()))
     request.uri.authority.foreach(authority => req.headers().add("Host", authority.renderString))
     req
   }


### PR DESCRIPTION
Before:
```
POST /test.txt HTTP/1.1
Authorization: Basic ****
Accept: text/*
transfer-encoding: chunked
Authorization: Basic ****
Accept: text/*
Host: 127.0.0.1:8888
```

After:
```
POST /test.txt HTTP/1.1
Authorization: Basic ***
Accept: text/*
transfer-encoding: chunked
Host: 127.0.0.1:8888
```
The problem was that for requests other than GET/HEAD (the ['else'](https://github.com/http4s/http4s-netty/blob/series/0.5/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala#L70)) the headers where added twice, once [here](https://github.com/http4s/http4s-netty/blob/series/0.5/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala#L84) and once [here](https://github.com/http4s/http4s-netty/blob/series/0.5/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala#L366)
