### PR TITLE
Add support for HTTP/2 Prior Knowledge to the server implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ inThisBuild(
 
 val http4sVersion = "0.23.18"
 
+val jetty = "11.0.13"
+
 val netty = "4.1.87.Final"
 
 val munit = "0.7.29"
@@ -60,6 +62,9 @@ lazy val server = project
     name := "http4s-netty-server",
     libraryDependencies ++= List(
       "io.netty" % "netty-codec-http2" % netty,
+      "org.eclipse.jetty" % "jetty-client" % jetty % Test,
+      "org.eclipse.jetty.http2" % "http2-client" % jetty % Test,
+      "org.eclipse.jetty.http2" % "http2-http-client-transport" % jetty % Test,
       "org.http4s" %% "http4s-server" % http4sVersion,
       "org.http4s" %% "http4s-dsl" % http4sVersion % Test,
       "ch.qos.logback" % "logback-classic" % "1.2.11" % Test,

--- a/server/src/main/scala/org/http4s/netty/server/NegotiationHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NegotiationHandler.scala
@@ -19,20 +19,9 @@ package server
 
 import cats.effect.Async
 import cats.effect.std.Dispatcher
-import com.typesafe.netty.http.HttpStreamsServerHandler
-import io.netty.channel.Channel
 import io.netty.channel.ChannelHandlerContext
-import io.netty.channel.ChannelInitializer
-import io.netty.channel.ChannelPipeline
-import io.netty.handler.codec.http.HttpRequestDecoder
-import io.netty.handler.codec.http.HttpResponseEncoder
-import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator
-import io.netty.handler.codec.http2.Http2FrameCodecBuilder
-import io.netty.handler.codec.http2.Http2MultiplexHandler
-import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec
 import io.netty.handler.ssl.ApplicationProtocolNames
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler
-import io.netty.handler.timeout.IdleStateHandler
 import org.http4s.HttpApp
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.websocket.WebSocketBuilder2
@@ -48,48 +37,24 @@ private[server] class NegotiationHandler[F[_]: Async](
   override def configurePipeline(ctx: ChannelHandlerContext, protocol: String): Unit =
     protocol match {
       case ApplicationProtocolNames.HTTP_2 =>
-        ctx
-          .pipeline()
-          .addLast(
-            Http2FrameCodecBuilder.forServer().build(),
-            new Http2MultiplexHandler(new ChannelInitializer[Channel] {
-              override def initChannel(ch: Channel): Unit = {
-                ch.pipeline().addLast(new Http2StreamFrameToHttpObjectCodec(true))
-                addToPipeline(ch.pipeline(), http1 = false)
-              }
-            })
-          )
-        ()
+        NettyPipelineHelpers.buildHttp2Pipeline(
+          ctx.pipeline,
+          config,
+          httpApp,
+          serviceErrorHandler,
+          dispatcher)
+
       case ApplicationProtocolNames.HTTP_1_1 =>
-        val pipeline = ctx.pipeline()
-        addToPipeline(pipeline, http1 = true)
+        NettyPipelineHelpers.buildHttp1Pipeline(
+          ctx.pipeline,
+          config,
+          httpApp,
+          serviceErrorHandler,
+          dispatcher)
+
       case _ => throw new IllegalStateException(s"Protocol: $protocol not supported")
     }
 
-  def addToPipeline(pipeline: ChannelPipeline, http1: Boolean): Unit = void {
-    if (http1) {
-      pipeline.addLast(
-        "http-decoder",
-        new HttpRequestDecoder(
-          config.maxInitialLineLength,
-          config.maxHeaderSize,
-          config.maxChunkSize))
-      pipeline.addLast("http-encoder", new HttpResponseEncoder())
-    }
-
-    if (config.idleTimeout.isFinite && config.idleTimeout.length > 0)
-      pipeline.addLast(
-        "idle-handler",
-        new IdleStateHandler(0, 0, config.idleTimeout.length, config.idleTimeout.unit))
-    pipeline
-      .addLast("websocket-aggregator", new WebSocketFrameAggregator(config.wsMaxFrameLength))
-      .addLast("serverStreamsHandler", new HttpStreamsServerHandler())
-      .addLast(
-        "http4s",
-        Http4sNettyHandler
-          .websocket(httpApp, serviceErrorHandler, config.wsMaxFrameLength, dispatcher)
-      )
-  }
 }
 
 object NegotiationHandler {

--- a/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.netty.server
+
+import cats.effect.Async
+import cats.effect.std.Dispatcher
+import com.typesafe.netty.http.HttpStreamsServerHandler
+import io.netty.channel.Channel
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.ChannelPipeline
+import io.netty.handler.codec.http.HttpRequestDecoder
+import io.netty.handler.codec.http.HttpResponseEncoder
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder
+import io.netty.handler.codec.http2.Http2MultiplexHandler
+import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec
+import io.netty.handler.timeout.IdleStateHandler
+import org.http4s.HttpApp
+import org.http4s.netty.void
+import org.http4s.server.ServiceErrorHandler
+import org.http4s.server.websocket.WebSocketBuilder2
+
+private object NettyPipelineHelpers {
+
+  def buildHttp2Pipeline[F[_]: Async](
+      pipeline: ChannelPipeline,
+      config: NegotiationHandler.Config,
+      httpApp: WebSocketBuilder2[F] => HttpApp[F],
+      serviceErrorHandler: ServiceErrorHandler[F],
+      dispatcher: Dispatcher[F]): Unit = void {
+    // H2, being a multiplexed protocol, needs to always be reading events in case
+    // it needs to close a stream, etc. Flow control is provided by the protocol itself.
+    pipeline.channel.config.setAutoRead(true)
+
+    pipeline
+      .addLast(
+        Http2FrameCodecBuilder.forServer().build(),
+        new Http2MultiplexHandler(new ChannelInitializer[Channel] {
+          override def initChannel(ch: Channel): Unit = {
+            ch.pipeline.addLast(new Http2StreamFrameToHttpObjectCodec(true))
+            addHttp4sHandlers(ch.pipeline, config, httpApp, serviceErrorHandler, dispatcher)
+          }
+        })
+      )
+  }
+
+  def buildHttp1Pipeline[F[_]: Async](
+      pipeline: ChannelPipeline,
+      config: NegotiationHandler.Config,
+      httpApp: WebSocketBuilder2[F] => HttpApp[F],
+      serviceErrorHandler: ServiceErrorHandler[F],
+      dispatcher: Dispatcher[F]): Unit = void {
+    // For HTTP/1.x pipelines the only backpressure we can exert is via the TCP
+    // flow control mechanisms. That means we set auto-read to false so that we
+    // can explicitly signal that we're ready for more data.
+    pipeline.channel.config.setAutoRead(false)
+
+    pipeline.addLast(
+      "http-decoder",
+      new HttpRequestDecoder(
+        config.maxInitialLineLength,
+        config.maxHeaderSize,
+        config.maxChunkSize))
+    pipeline.addLast("http-encoder", new HttpResponseEncoder())
+    addHttp4sHandlers(pipeline, config, httpApp, serviceErrorHandler, dispatcher)
+  }
+
+  private[this] def addHttp4sHandlers[F[_]: Async](
+      pipeline: ChannelPipeline,
+      config: NegotiationHandler.Config,
+      httpApp: WebSocketBuilder2[F] => HttpApp[F],
+      serviceErrorHandler: ServiceErrorHandler[F],
+      dispatcher: Dispatcher[F]): Unit = void {
+
+    if (config.idleTimeout.isFinite && config.idleTimeout.length > 0) {
+      pipeline.addLast(
+        "idle-handler",
+        new IdleStateHandler(0, 0, config.idleTimeout.length, config.idleTimeout.unit))
+    }
+
+    pipeline
+      .addLast("websocket-aggregator", new WebSocketFrameAggregator(config.wsMaxFrameLength))
+      .addLast("serverStreamsHandler", new HttpStreamsServerHandler())
+      .addLast(
+        "http4s",
+        Http4sNettyHandler
+          .websocket(httpApp, serviceErrorHandler, config.wsMaxFrameLength, dispatcher)
+      )
+  }
+}

--- a/server/src/main/scala/org/http4s/netty/server/PriorKnowledgeDetectionHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/PriorKnowledgeDetectionHandler.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.netty
+package server
+
+import cats.effect.Async
+import cats.effect.std.Dispatcher
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufUtil
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelPipeline
+import io.netty.handler.codec.ByteToMessageDecoder
+import io.netty.handler.codec.http2.Http2CodecUtil
+import org.http4s.HttpApp
+import org.http4s.server.ServiceErrorHandler
+import org.http4s.server.websocket.WebSocketBuilder2
+import org.log4s.getLogger
+
+import java.util
+
+private class PriorKnowledgeDetectionHandler[F[_]: Async](
+    config: NegotiationHandler.Config,
+    httpApp: WebSocketBuilder2[F] => HttpApp[F],
+    serviceErrorHandler: ServiceErrorHandler[F],
+    dispatcher: Dispatcher[F]
+) extends ByteToMessageDecoder {
+
+  private[this] val logger = getLogger
+
+  // The `connectionPrefaceBuf()` method returns a duplicate
+  private[this] val preface = Http2CodecUtil.connectionPrefaceBuf()
+
+  override protected def handlerRemoved0(ctx: ChannelHandlerContext): Unit = void {
+    preface.release()
+  }
+
+  override def decode(ctx: ChannelHandlerContext, in: ByteBuf, out: util.List[AnyRef]): Unit = {
+    logger.trace(s"decode: ctx = $ctx, in.readableBytes = ${in.readableBytes}")
+    if (ByteBufUtil.equals(in, 0, preface, 0, Math.min(in.readableBytes, preface.readableBytes))) {
+      // So far they're equal. Have we read the whole message? If so, it's H2 prior knowledge.
+      // Otherwise we just don't have enough bytes yet to be sure.
+      if (preface.readableBytes <= in.readableBytes) {
+        initializeH2PriorKnowledge(ctx.pipeline)
+      }
+    } else {
+      // Doesn't match the prior knowledge preface. Initialize H1 pipeline.
+      initializeH1(ctx.pipeline)
+    }
+  }
+
+  private[this] def initializeH2PriorKnowledge(pipeline: ChannelPipeline): Unit = void {
+    logger.trace(s"initializing h2 pipeline. Current pipeline: $pipeline")
+    NettyPipelineHelpers.buildHttp2Pipeline(
+      pipeline,
+      config,
+      httpApp,
+      serviceErrorHandler,
+      dispatcher)
+    pipeline.remove(this)
+  }
+
+  private[this] def initializeH1(pipeline: ChannelPipeline): Unit = void {
+    logger.trace(s"initializing h1 pipeline. Current pipeline: $pipeline")
+    NettyPipelineHelpers.buildHttp1Pipeline(
+      pipeline,
+      config,
+      httpApp,
+      serviceErrorHandler,
+      dispatcher)
+    pipeline.remove(this)
+  }
+}


### PR DESCRIPTION
Problem

Right now we support HTTP/2 only as a negotiated protocol via ALPN. This is unfortunate as HTTP/2 is just as good cleartext as it is over TLS.

Solution

Add HTTP/2 prior knowledge detection to the cleartext pathway for the server. This is done by looking for the magic preface which is not valid as a HTTP/1.x message preface and initialize the pipeline accordingly.