### PR TITLE
Websocket client - use reactive streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,9 @@ lazy val client = project
         "org.http4s.netty.client.Http4sChannelPoolMap.this"),
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.netty.client.Http4sHandler$"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap.resource")
+        "org.http4s.netty.client.Http4sChannelPoolMap.resource"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.netty.client.Http4sWebsocketHandler#Conn.this")
     )
   )
 

--- a/client/src/main/scala/org/http4s/netty/client/Http4sWebsocketHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sWebsocketHandler.scala
@@ -32,7 +32,8 @@ import org.http4s.client.websocket.WSFrame
 import org.http4s.netty.NettyModelConversion
 import org.http4s.netty.client.Http4sWebsocketHandler.fromWSFrame
 import org.http4s.netty.client.Http4sWebsocketHandler.toWSFrame
-import org.reactivestreams.{Subscriber, Subscription}
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import scodec.bits.ByteVector
 
 import scala.concurrent.ExecutionContext

--- a/client/src/main/scala/org/http4s/netty/client/Http4sWebsocketHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sWebsocketHandler.scala
@@ -145,8 +145,6 @@ private[client] class Http4sWebsocketHandler[F[_]](
             val list = wsfs.toList
             list.foreach(wsf => ctx.write(fromWSFrame(wsf)))
             ctx.flush()
-          } else {
-            dispatcher.unsafeRunAndForget(closed.complete(()))
           }
           ()
         })

--- a/client/src/main/scala/org/http4s/netty/client/Http4sWebsocketHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sWebsocketHandler.scala
@@ -143,7 +143,7 @@ private[client] class Http4sWebsocketHandler[F[_]](
         runInNetty(F.delay {
           if (ctx.channel().isActive) {
             val list = wsfs.toList
-            list.foreach(wsf => ctx.write(fromWSFrame(wsf)).sync())
+            list.foreach(wsf => ctx.write(fromWSFrame(wsf)))
             ctx.flush()
           }
           ()

--- a/client/src/test/scala/org/http4s/netty/client/EmberWebsocketTest.scala
+++ b/client/src/test/scala/org/http4s/netty/client/EmberWebsocketTest.scala
@@ -62,14 +62,17 @@ class EmberWebsocketTest extends IOSuite {
           recv <- conn.receiveStream.compile.toList
         } yield recv
       }
-      .assertEquals(
-        List(
-          WSFrame.Text("bar"),
-          WSFrame.Binary(ByteVector(3, 99, 12)),
-          WSFrame.Text("foo"),
-          WSFrame.Close(1000, "")
-        )
-      )
+      .map { list =>
+        println(list)
+        assertEquals(
+          list,
+          List(
+            WSFrame.Text("bar"),
+            WSFrame.Binary(ByteVector(3, 99, 12)),
+            WSFrame.Text("foo"),
+            WSFrame.Close(1000, "")
+          ))
+      }
   }
 
   test("send and receive frames in high-level mode") {

--- a/client/src/test/scala/org/http4s/netty/client/EmberWebsocketTest.scala
+++ b/client/src/test/scala/org/http4s/netty/client/EmberWebsocketTest.scala
@@ -36,7 +36,7 @@ class EmberWebsocketTest extends IOSuite {
         .default[IO]
         .withHttpWebSocketApp(echoRoutes(_).orNotFound)
         .withPort(port"19999")
-        .withShutdownTimeout(1.second)
+        .withShutdownTimeout(100.milli)
         .build
         .map(s => httpToWsUri(s.baseUri))
     } yield netty,

--- a/client/src/test/scala/org/http4s/netty/client/EmberWebsocketTest.scala
+++ b/client/src/test/scala/org/http4s/netty/client/EmberWebsocketTest.scala
@@ -35,7 +35,7 @@ class EmberWebsocketTest extends IOSuite {
       netty <- EmberServerBuilder
         .default[IO]
         .withHttpWebSocketApp(echoRoutes(_).orNotFound)
-        .withPort(port"19999")
+        .withPort(port"0")
         .withShutdownTimeout(100.milli)
         .build
         .map(s => httpToWsUri(s.baseUri))
@@ -62,17 +62,13 @@ class EmberWebsocketTest extends IOSuite {
           recv <- conn.receiveStream.compile.toList
         } yield recv
       }
-      .map { list =>
-        println(list)
-        assertEquals(
-          list,
-          List(
-            WSFrame.Text("bar"),
-            WSFrame.Binary(ByteVector(3, 99, 12)),
-            WSFrame.Text("foo"),
-            WSFrame.Close(1000, "")
-          ))
-      }
+      .assertEquals(
+        List(
+          WSFrame.Text("bar"),
+          WSFrame.Binary(ByteVector(3, 99, 12)),
+          WSFrame.Text("foo"),
+          WSFrame.Close(1000, "")
+        ))
   }
 
   test("send and receive frames in high-level mode") {


### PR DESCRIPTION
Try to use reactive streams for frames to avoid queuing problem.