### PR TITLE
Http/2 client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,25 @@ lazy val client = project
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.http4s.netty.client.Http4sChannelPoolMap.resource"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.Http4sWebsocketHandler#Conn.this")
+        "org.http4s.netty.client.Http4sWebsocketHandler#Conn.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.netty.client.Http4sChannelPoolMap.attr"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.netty.client.Http4sChannelPoolMap#MyFixedChannelPool.this"),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.http4s.netty.client.Http4sChannelPoolMap$WrappedChannelPoolHandler"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.netty.client.SSLContextOption#Provided.sslContext"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.netty.client.SSLContextOption#Provided.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.netty.client.SSLContextOption#Provided.copy$default$1"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.netty.client.SSLContextOption#Provided.this"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.netty.client.SSLContextOption#Provided.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.netty.client.SSLContextOption#Provided._1")
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -114,56 +114,19 @@ lazy val client = project
     ),
     libraryDependencies ++= nativeNettyModules,
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[Problem]("org.http4s.netty.client.Http4sChannelPoolMap"),
-      ProblemFilters.exclude[MissingClassProblem](
-        "org.http4s.netty.client.NettyClientBuilder$EventLoopHolder$"),
-      ProblemFilters.exclude[MissingClassProblem](
-        "org.http4s.netty.client.NettyClientBuilder$SSLContextOption*"),
-      ProblemFilters.exclude[MissingClassProblem](
-        "org.http4s.netty.client.NettyClientBuilder$EventLoopHolder"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap#Config.sslConfig"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap#Config.copy$default$7"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap#Config.*"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap#Config.copy"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap#Config.apply"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap#Config.this"),
+      // internal types
+      ProblemFilters.exclude[Problem]("org.http4s.netty.client.Http4sChannelPoolMap*"),
+      ProblemFilters.exclude[Problem]("org.http4s.netty.client.Http4sHandler*"),
+      ProblemFilters.exclude[Problem]("org.http4s.netty.client.Http4sWebsocketHandler*"),
+      ProblemFilters.exclude[Problem]("org.http4s.netty.client.SSLContextOption*"),
+      ProblemFilters.exclude[MissingClassProblem]("org.http4s.netty.client.NettyClientBuilder$*"),
+      // updated builder
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "org.http4s.netty.client.NettyClientBuilder.this"),
       ProblemFilters.exclude[MissingFieldProblem](
         "org.http4s.netty.client.NettyClientBuilder.SSLContextOption"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.NettyWSClientBuilder.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap.this"),
-      ProblemFilters.exclude[MissingClassProblem]("org.http4s.netty.client.Http4sHandler$"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap.resource"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.Http4sWebsocketHandler#Conn.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap.attr"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap#MyFixedChannelPool.this"),
-      ProblemFilters.exclude[MissingClassProblem](
-        "org.http4s.netty.client.Http4sChannelPoolMap$WrappedChannelPoolHandler"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.http4s.netty.client.SSLContextOption#Provided.sslContext"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.netty.client.SSLContextOption#Provided.copy"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.http4s.netty.client.SSLContextOption#Provided.copy$default$1"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.netty.client.SSLContextOption#Provided.this"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.netty.client.SSLContextOption#Provided.apply"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.http4s.netty.client.SSLContextOption#Provided._1")
+        "org.http4s.netty.client.NettyWSClientBuilder.this")
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,7 @@ lazy val client = project
     name := "http4s-netty-client",
     libraryDependencies ++= List(
       "org.http4s" %% "http4s-client" % http4sVersion,
+      "io.netty" % "netty-codec-http2" % netty,
       "io.netty" % "netty-handler-proxy" % netty,
       "org.http4s" %% "http4s-client-testkit" % http4sVersion % Test,
       "org.http4s" %% "http4s-ember-server" % http4sVersion % Test,

--- a/client/src/main/scala/org/http4s/netty/client/Http4sChannelPoolMap.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sChannelPoolMap.scala
@@ -28,12 +28,11 @@ import io.netty.channel.Channel
 import io.netty.channel.ChannelFuture
 import io.netty.channel.pool.AbstractChannelPoolHandler
 import io.netty.channel.pool.AbstractChannelPoolMap
-import io.netty.channel.pool.ChannelPoolHandler
 import io.netty.channel.pool.FixedChannelPool
 import io.netty.handler.codec.http.HttpClientCodec
+import io.netty.handler.codec.http.HttpRequest
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
-import io.netty.util.AttributeKey
 import io.netty.util.concurrent.Future
 import org.http4s.Request
 import org.http4s.Response
@@ -42,39 +41,40 @@ import org.http4s.Uri.Scheme
 import org.http4s.client.RequestKey
 
 import java.net.ConnectException
+import java.nio.channels.ClosedChannelException
 import scala.concurrent.duration.Duration
 
-private[client] class Http4sChannelPoolMap[F[_]: Async](
+private[client] class Http4sChannelPoolMap[F[_]](
     bootstrap: Bootstrap,
     config: Http4sChannelPoolMap.Config,
     dispatcher: Dispatcher[F]
-) extends AbstractChannelPoolMap[RequestKey, FixedChannelPool] {
+)(implicit F: Async[F])
+    extends AbstractChannelPoolMap[RequestKey, FixedChannelPool] {
+
   private[this] val logger = org.log4s.getLogger
+  private val modelConversion = new NettyModelConversion[F]
 
   def run(request: Request[F]): Resource[F, Response[F]] = {
     val key = RequestKey.fromRequest(request)
-    val pool = get(key)
+    val pool = get(key).asInstanceOf[MyFixedChannelPool]
+    val handler = pool.handler()
 
     Resource
       .make(Http4sChannelPoolMap.fromFuture(pool.acquire())) { channel =>
         Http4sChannelPoolMap.fromFuture(pool.release(channel)).void
       }
-      .flatMap(_.pipeline().get(classOf[Http4sHandler[F]]).dispatch(request))
+      .flatMap(channel => handler.dispatch(channel, request))
   }
 
   override def newPool(key: RequestKey): FixedChannelPool =
-    new MyFixedChannelPool(
-      bootstrap,
-      new WrappedChannelPoolHandler(key, config),
-      config.maxConnections,
-      key)
+    new MyFixedChannelPool(bootstrap, config.maxConnections, key)
 
-  class MyFixedChannelPool(
-      bs: Bootstrap,
-      handler: ChannelPoolHandler,
-      maxConnections: Int,
-      key: RequestKey)
-      extends FixedChannelPool(bs, handler, maxConnections) {
+  class MyFixedChannelPool(bs: Bootstrap, maxConnections: Int, key: RequestKey)
+      extends FixedChannelPool(bs, new PoolHandler(key, config), maxConnections) {
+
+    override def handler(): PoolHandler =
+      super.handler().asInstanceOf[PoolHandler]
+
     override def connectChannel(bs: Bootstrap): ChannelFuture = {
       val host = key.authority.host.value
       val port = (key.scheme, key.authority.port) match {
@@ -90,18 +90,56 @@ private[client] class Http4sChannelPoolMap[F[_]: Async](
     }
   }
 
-  class WrappedChannelPoolHandler(
-      key: RequestKey,
-      config: Http4sChannelPoolMap.Config
-  ) extends AbstractChannelPoolHandler {
-    override def channelAcquired(ch: Channel): Unit = {
-      logger.trace(s"Connected to $ch")
-      ch.attr(Http4sChannelPoolMap.attr).set(key)
+  class PoolHandler(key: RequestKey, config: Http4sChannelPoolMap.Config)
+      extends AbstractChannelPoolHandler {
+    private val promises = collection.mutable.Queue[Http4sChannelPoolMap.Callback[F]]()
+
+    private[netty] def dispatch(channel: Channel, request: Request[F]): Resource[F, Response[F]] = {
+      val key = RequestKey.fromRequest(request)
+
+      modelConversion
+        .toNettyRequest(request)
+        .evalMap { nettyRequest =>
+          F.async[Resource[F, Response[F]]] { cb =>
+            if (channel.eventLoop().inEventLoop) {
+              safedispatch(channel, nettyRequest, key, cb)
+            } else {
+              channel.eventLoop().execute(() => safedispatch(channel, nettyRequest, key, cb))
+            }
+            // This is only used to cleanup if the resource is interrupted.
+            F.pure(Some(F.delay(channel.close()).void))
+          }
+        }
+        .flatMap(identity)
     }
+
+    private def safedispatch(
+        channel: Channel,
+        request: HttpRequest,
+        key: RequestKey,
+        callback: Http4sChannelPoolMap.Callback[F]): Unit = void {
+      // always enqueue
+      promises.enqueue(callback)
+      if (channel.isActive) {
+        logger.trace(s"ch $channel: sending request to $key")
+        // The voidPromise lets us receive failed-write signals from the
+        // exceptionCaught method.
+        channel.writeAndFlush(request, channel.voidPromise)
+        logger.trace(s"ch $channel: after request to $key")
+      } else {
+        // make sure we call all enqueued promises
+        logger.info(s"ch $channel: message dispatched by closed channel to destination $key.")
+        promises.foreach(cb => cb(Left(new ClosedChannelException)))
+        promises.clear()
+        channel.close()
+      }
+    }
+
+    override def channelAcquired(ch: Channel): Unit =
+      logger.trace(s"Connected to $ch")
 
     override def channelCreated(ch: Channel): Unit = void {
       logger.trace(s"Created $ch")
-      ch.attr(Http4sChannelPoolMap.attr).set(key)
       buildPipeline(ch)
     }
 
@@ -148,13 +186,13 @@ private[client] class Http4sChannelPoolMap[F[_]: Async](
             "timeout",
             new IdleStateHandler(0, 0, config.idleTimeout.length, config.idleTimeout.unit))
       }
-      pipeline.addLast("http4s", new Http4sHandler[F](dispatcher))
+      pipeline.addLast("http4s", new Http4sHandler[F](dispatcher, promises))
     }
   }
 }
 
 private[client] object Http4sChannelPoolMap {
-  val attr: AttributeKey[RequestKey] = AttributeKey.valueOf[RequestKey](classOf[RequestKey], "key")
+  type Callback[F[_]] = Either[Throwable, Resource[F, Response[F]]] => Unit
 
   final case class Config(
       maxInitialLength: Int,

--- a/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
@@ -53,6 +53,13 @@ private[netty] class Http4sHandler[F[_]](
     }
   }
 
+  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+    if (!ctx.channel().config().isAutoRead) {
+      ctx.read()
+    }
+    super.channelActive(ctx)
+  }
+
   override def channelInactive(ctx: ChannelHandlerContext): Unit =
     onException(ctx, new ClosedChannelException())
 

--- a/client/src/main/scala/org/http4s/netty/client/SSLContextOption.scala
+++ b/client/src/main/scala/org/http4s/netty/client/SSLContextOption.scala
@@ -33,7 +33,7 @@ private[client] object SSLContextOption {
     Protocol.ALPN,
     SelectorFailureBehavior.NO_ADVERTISE,
     SelectedListenerFailureBehavior.ACCEPT,
-    //ApplicationProtocolNames.HTTP_2,
+    ApplicationProtocolNames.HTTP_2,
     ApplicationProtocolNames.HTTP_1_1
   )
 

--- a/client/src/test/scala/org/http4s/netty/client/TestMain.scala
+++ b/client/src/test/scala/org/http4s/netty/client/TestMain.scala
@@ -8,6 +8,6 @@ import org.http4s.syntax.literals._
 object TestMain extends IOApp.Simple {
   override def run: IO[Unit] =
     NettyClientBuilder[IO].resource.use { client =>
-      client.status(Request[IO](uri = uri"https://www.vg.no/")).flatMap(IO.println)
+      client.status(Request[IO](uri = uri"https://www.nrk.no/")).flatMap(IO.println)
     }
 }

--- a/client/src/test/scala/org/http4s/netty/client/TestMain.scala
+++ b/client/src/test/scala/org/http4s/netty/client/TestMain.scala
@@ -1,0 +1,13 @@
+package org.http4s.netty.client
+
+import cats.effect.IO
+import cats.effect.IOApp
+import org.http4s.Request
+import org.http4s.syntax.literals._
+
+object TestMain extends IOApp.Simple {
+  override def run: IO[Unit] =
+    NettyClientBuilder[IO].resource.use { client =>
+      client.status(Request[IO](uri = uri"https://www.vg.no/")).flatMap(IO.println)
+    }
+}

--- a/client/src/test/scala/org/http4s/netty/client/TestMain.scala
+++ b/client/src/test/scala/org/http4s/netty/client/TestMain.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.netty.client
 
 import cats.effect.IO

--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -87,6 +87,11 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
         }
     }
   }
+  def nettyResponseResource(channel: Channel, response: HttpResponse) =
+    fromNettyResponse(response)
+      .map { case (res, cleanup) =>
+        Resource.make(F.pure(res))(_ => cleanup(channel))
+      }
 
   def fromNettyResponse(response: HttpResponse): F[(Response[F], (Channel) => F[Unit])] = {
     logger.trace(s"converting response: $response")


### PR DESCRIPTION
Limitations: 
- Only on https and requires alpn.
- FullHttpResponses only, meaning all bytes are buffered in memory

More mima exlusions needed for internal types, we should consider moving main to 1.0 milestones and maybe start a 0.7 series.
0.6 will then be defunkt.

