### PR TITLE
Add MacOS Aarch64 runtime dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ val nativeNettyModules =
     "io.netty.incubator" % "netty-incubator-transport-classes-io_uring" % io_uring,
     ("io.netty" % "netty-transport-native-epoll" % netty).classifier("linux-x86_64") % Runtime,
     ("io.netty" % "netty-transport-native-kqueue" % netty).classifier("osx-x86_64") % Runtime,
+    ("io.netty" % "netty-transport-native-kqueue" % netty).classifier("osx-aarch_64") % Runtime,
     ("io.netty.incubator" % "netty-incubator-transport-native-io_uring" % io_uring)
       .classifier("linux-x86_64") % Runtime
   )


### PR DESCRIPTION
On Mac with M1 chips, Netty Server does not start because `io.netty.channel.kqueue.KQueue.isSupported` returns `false`.
Indeed, only x86 native KQueue runtime dependency is set:
https://github.com/http4s/http4s-netty/blob/46634c942e6860336417b9b59548255270827db8/build.sbt#L38

This PR simply adds the `osx-aarch_64` runtime dependency.

Fix validated locally on MacOS Sonoma with Apple M1 Max chip:

```
[info] 12:25:05 | INFO | o.h.n.s.NettyServerBuilder | Using KQueue
[info] 12:25:05 | INFO | o.h.n.s.NettyServerBuilder | Started Http4s Netty Server at http://[::]:8080/
```