### PR TITLE
Also include epoll aarch dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ val nativeNettyModules =
     "io.netty" % "netty-transport-classes-kqueue" % netty,
     "io.netty.incubator" % "netty-incubator-transport-classes-io_uring" % io_uring,
     ("io.netty" % "netty-transport-native-epoll" % netty).classifier("linux-x86_64") % Runtime,
+    ("io.netty" % "netty-transport-native-epoll" % netty).classifier("linux-aarch_64") % Runtime,
     ("io.netty" % "netty-transport-native-kqueue" % netty).classifier("osx-x86_64") % Runtime,
     ("io.netty" % "netty-transport-native-kqueue" % netty).classifier("osx-aarch_64") % Runtime,
     ("io.netty.incubator" % "netty-incubator-transport-native-io_uring" % io_uring)


### PR DESCRIPTION
Without this dependency Netty fails to startup on Apple silicon when using Netty in Docker.

Workaround that we use atm:
`"io.netty"                     % "netty-transport-native-epoll" % "4.1.108.Final" classifier "linux-aarch_64"`