### PR TITLE
NettyServerBuilder withWebSocketMaxFrameLength method

### DIFF
--- a/server/src/main/scala/org/http4s/netty/server/NettyServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NettyServerBuilder.scala
@@ -187,6 +187,8 @@ final class NettyServerBuilder[F[_]] private (
     copy(serviceErrorHandler = handler)
   def withNettyChannelOptions(opts: NettyChannelOptions): Self =
     copy(nettyChannelOptions = opts)
+  def withWebSocketMaxFrameLength(wsMaxFrameLength: Int): Self =
+    copy(wsMaxFrameLength = wsMaxFrameLength)
   def withWebSocketCompression: Self = copy(wsCompression = true)
   def withoutWebSocketCompression: Self = copy(wsCompression = false)
 


### PR DESCRIPTION
it's nice to have the way to configure web socket max frame length to avoid
io.netty.handler.codec.http.websocketx.CorruptedWebSocketFrameException: Max frame length of 65536 has been exceeded.
in some cases