### PR TITLE
Specify websocket decompression buffer size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val http4sVersion = "0.23.30"
 
 val jetty = "12.0.21"
 
-val netty = "4.1.121.Final"
+val netty = "4.1.122.Final"
 
 val munit = "1.1.1"
 val munitScalaCheck = "1.1.0"

--- a/client/src/main/scala/org/http4s/netty/client/NettyWSClientBuilder.scala
+++ b/client/src/main/scala/org/http4s/netty/client/NettyWSClientBuilder.scala
@@ -196,7 +196,9 @@ class NettyWSClientBuilder[F[_]](
               if (wsCompression) {
                 void(
                   pipeline
-                    .addLast("websocket-compression", WebSocketClientCompressionHandler.INSTANCE))
+                    .addLast(
+                      "websocket-compression",
+                      new WebSocketClientCompressionHandler(maxFramePayloadLength)))
               }
               pipeline.addLast("protocol-handler", websocketinit)
               pipeline.addLast(

--- a/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
@@ -95,7 +95,10 @@ private object NettyPipelineHelpers {
     }
 
     if (config.wsCompression) {
-      void(pipeline.addLast("websocket-compression", new WebSocketServerCompressionHandler))
+      void(
+        pipeline.addLast(
+          "websocket-compression",
+          new WebSocketServerCompressionHandler(config.wsMaxFrameLength)))
     }
     pipeline.addLast("websocket-aggregator", new WebSocketFrameAggregator(config.wsMaxFrameLength))
     pipeline.addLast("serverStreamsHandler", new HttpStreamsServerHandler())


### PR DESCRIPTION
Currently the maximum websocket frame size is limited with the `wsMaxFrameLength` parameter. However, if `per-message-deflate` extension is enabled and a frame is compressed, the frame size is checked before decompression. It could cause a situation when somebody sends a small malicious message which would be higher than the heap size after decompression and would cause OOM.

This issue has already been addressed in Netty since 4.1.122, but it requires some changes in http4-netty as well. This PR provides the maximum decompress buffer size to Netty the same as the maximum websocket frame size.