### PR TITLE
Implement direct streaming using cats effect primitives

### DIFF
--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -33,7 +33,6 @@ import org.http4s.Header
 import org.http4s.headers.`Content-Length`
 import org.http4s.headers.`Transfer-Encoding`
 import org.http4s.headers.{Connection => ConnHeader}
-import org.http4s.syntax.header._
 import org.http4s.{HttpVersion => HV}
 import org.playframework.netty.http._
 import org.reactivestreams.FlowAdapters
@@ -274,7 +273,7 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
         // Note: Depending on the status of the response, this may be removed further
         // down the netty pipeline by the HttpResponseEncoder
         if (httpRequest.method == Method.HEAD)
-          addHeadResponseHeaders(httpResponse, minorVersionIs0, r.headers())
+          addHeadResponseHeaders(httpResponse, r.headers())
         Resource.pure[F, DefaultHttpResponse](r)
       }
 
@@ -358,25 +357,16 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
     addTransferOrContentLengthHeaders(headers, minorIs0, response.headers())
   }
 
-  /** Add TE/CL headers for HEAD responses (which have no body but should report the headers they
-    * would have sent with a GET).
+  /** Add Content-Length for HEAD responses so the client knows the size the GET body would have.
+    *
+    * Transfer-Encoding is intentionally omitted: RFC 9110 Section 9.3.2 says payload headers MAY be
+    * omitted from HEAD responses, and sending `Transfer-Encoding: chunked` causes the Netty HTTP
+    * client to hang waiting for a chunked body that never arrives.
     */
-  protected def addHeadResponseHeaders(
-      httpResponse: Response[F],
-      minorIs0: Boolean,
-      nettyHeaders: HttpHeaders): Unit = {
-    val transferEncoding = httpResponse.headers.get[`Transfer-Encoding`]
-    val contentLength = httpResponse.contentLength
-    (transferEncoding, contentLength) match {
-      case (Some(enc), _) if enc.hasChunked && !minorIs0 =>
-        nettyHeaders.add(HttpHeaderNames.TRANSFER_ENCODING, enc.toString)
-        ()
-      case (_, Some(len)) =>
-        nettyHeaders.add(HttpHeaderNames.CONTENT_LENGTH, len)
-        ()
-      case _ => // no-op
+  protected def addHeadResponseHeaders(httpResponse: Response[F], nettyHeaders: HttpHeaders): Unit =
+    httpResponse.contentLength.foreach { len =>
+      nettyHeaders.add(HttpHeaderNames.CONTENT_LENGTH, len)
     }
-  }
 
   /** Add Date and Connection headers to a response.
     *

--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -236,7 +236,7 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
 
   /** Append all headers that _aren't_ `Transfer-Encoding` or `Content-Length`
     */
-  private[this] def appendSomeToNetty(header: Header.Raw, nettyHeaders: HttpHeaders): Unit =
+  protected def appendSomeToNetty(header: Header.Raw, nettyHeaders: HttpHeaders): Unit =
     if (header.name != `Transfer-Encoding`.name && header.name != `Content-Length`.name)
       void(nettyHeaders.add(header.name.toString, header.value))
 
@@ -270,35 +270,16 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
           HttpResponseStatus.valueOf(httpResponse.status.code)
         )
         httpResponse.headers.foreach(appendSomeToNetty(_, r.headers()))
-        // HEAD: restore Content-Length so the client knows the representation size.
-        // We intentionally omit Transfer-Encoding: the HttpServerCodec strips it
-        // from the wire anyway, and adding it was the root cause of illegal chunk
-        // framing on HEAD responses when a standalone HttpResponseEncoder was used.
-        if (httpRequest.method == Method.HEAD) {
-          httpResponse.contentLength.foreach { len =>
-            r.headers().add(HttpHeaderNames.CONTENT_LENGTH, len)
-            ()
-          }
-        }
+        // Edge case: HEAD
+        // Note: Depending on the status of the response, this may be removed further
+        // down the netty pipeline by the HttpResponseEncoder
+        if (httpRequest.method == Method.HEAD)
+          addHeadResponseHeaders(httpResponse, minorVersionIs0, r.headers())
         Resource.pure[F, DefaultHttpResponse](r)
       }
 
     response.map { response =>
-      // Add the cached date if not present
-      if (!response.headers().contains(HttpHeaderNames.DATE)) {
-        response.headers().add(HttpHeaderNames.DATE, dateString)
-        ()
-      }
-
-      httpRequest.headers.get[ConnHeader] match {
-        case Some(conn) =>
-          response.headers().add(HttpHeaderNames.CONNECTION, conn.value)
-        case None =>
-          if (minorVersionIs0) { // Close by default for Http 1.0
-            response.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE)
-            ()
-          }
-      }
+      addDateAndConnectionHeaders(response.headers(), httpRequest, dateString, minorVersionIs0)
       response
     }
   }
@@ -325,19 +306,20 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
         response
       }
 
-  private def transferEncoding(
+  /** Write TE/CL headers to the given HttpHeaders based on the http4s Headers. Extracted so
+    * subclasses can use it without needing a StreamedHttpMessage.
+    */
+  protected def addTransferOrContentLengthHeaders(
       headers: Headers,
       minorIs0: Boolean,
-      response: StreamedHttpMessage): Unit = {
-    headers.foreach(appendSomeToNetty(_, response.headers()))
+      nettyHeaders: HttpHeaders): Unit = {
     val transferEncoding = headers.get[`Transfer-Encoding`]
     headers.get[`Content-Length`] match {
       case Some(clenHeader) if transferEncoding.forall(!_.hasChunked) || minorIs0 =>
         // HTTP 1.1: we have a length and no chunked encoding
         // HTTP 1.0: we have a length
-
         // Ignore transfer-encoding if it's not chunked
-        response.headers().add(HttpHeaderNames.CONTENT_LENGTH, clenHeader.length)
+        nettyHeaders.add(HttpHeaderNames.CONTENT_LENGTH, clenHeader.length)
 
       case _ =>
         if (!minorIs0)
@@ -347,17 +329,14 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
                 tr.values.map { v =>
                   // Necessary due to the way netty does transfer encoding checks.
                   if (v != TransferCoding.chunked) {
-                    response.headers().add(HttpHeaderNames.TRANSFER_ENCODING, v.coding)
+                    nettyHeaders.add(HttpHeaderNames.TRANSFER_ENCODING, v.coding)
                     ()
                   }
                 }
-                response
-                  .headers()
+                nettyHeaders
                   .add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
               case None =>
-                // Netty reactive streams transfers bodies as chunked transfer encoding anyway.
-                response
-                  .headers()
+                nettyHeaders
                   .add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
             }
           }
@@ -369,6 +348,63 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
       // By just spamming http 1.0 Requests, forcing in-memory buffering and OOM.
     }
     ()
+  }
+
+  private def transferEncoding(
+      headers: Headers,
+      minorIs0: Boolean,
+      response: StreamedHttpMessage): Unit = {
+    headers.foreach(appendSomeToNetty(_, response.headers()))
+    addTransferOrContentLengthHeaders(headers, minorIs0, response.headers())
+  }
+
+  /** Add TE/CL headers for HEAD responses (which have no body but should report the headers they
+    * would have sent with a GET).
+    */
+  protected def addHeadResponseHeaders(
+      httpResponse: Response[F],
+      minorIs0: Boolean,
+      nettyHeaders: HttpHeaders): Unit = {
+    val transferEncoding = httpResponse.headers.get[`Transfer-Encoding`]
+    val contentLength = httpResponse.contentLength
+    (transferEncoding, contentLength) match {
+      case (Some(enc), _) if enc.hasChunked && !minorIs0 =>
+        nettyHeaders.add(HttpHeaderNames.TRANSFER_ENCODING, enc.toString)
+        ()
+      case (_, Some(len)) =>
+        nettyHeaders.add(HttpHeaderNames.CONTENT_LENGTH, len)
+        ()
+      case _ => // no-op
+    }
+  }
+
+  /** Add Date and Connection headers to a response.
+    *
+    * @param dateString
+    *   Cached formatted date string. Added only if no Date header is already present.
+    * @param minorIs0
+    *   True for HTTP/1.0. HTTP/1.0 defaults to Connection: close.
+    */
+  protected def addDateAndConnectionHeaders(
+      nettyHeaders: HttpHeaders,
+      httpRequest: Request[F],
+      dateString: String,
+      minorIs0: Boolean
+  ): Unit = {
+    if (!nettyHeaders.contains(HttpHeaderNames.DATE)) {
+      nettyHeaders.add(HttpHeaderNames.DATE, dateString)
+      ()
+    }
+    httpRequest.headers.get[ConnHeader] match {
+      case Some(conn) =>
+        nettyHeaders.add(HttpHeaderNames.CONNECTION, ConnHeader.headerInstance.value(conn))
+        ()
+      case None =>
+        if (minorIs0) {
+          nettyHeaders.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE)
+          ()
+        }
+    }
   }
 
   /** Convert a Chunk to a Netty ByteBuf. */
@@ -413,6 +449,16 @@ object NettyModelConversion {
     }
     Headers(buffer.result())
   }
+
+  /** Resolve an http4s HttpVersion to a Netty HttpVersion plus a flag indicating HTTP/1.0. */
+  private[netty] def resolveHttpVersion(
+      version: HV): (io.netty.handler.codec.http.HttpVersion, Boolean) =
+    if (version == HV.`HTTP/1.1`)
+      (io.netty.handler.codec.http.HttpVersion.HTTP_1_1, false)
+    else if (version == HV.`HTTP/1.0`)
+      (io.netty.handler.codec.http.HttpVersion.HTTP_1_0, true)
+    else
+      (io.netty.handler.codec.http.HttpVersion.valueOf(version.toString), false)
 
   private[netty] def bytebufToArray(buf: ByteBuf, release: Boolean = true): Array[Byte] = {
     val array = ByteBufUtil.getBytes(buf)

--- a/server/src/main/java/org/playframework/netty/http/HttpStreamsServerHandlerBridge.java
+++ b/server/src/main/java/org/playframework/netty/http/HttpStreamsServerHandlerBridge.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.playframework.netty.http;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+/**
+ * Java bridge that provides access to methods on the package-private
+ * {@link HttpStreamsHandler} class. Scala 3 enforces Java access modifiers at
+ * runtime so a Scala subclass in another package cannot call
+ * {@code super.write()} or {@code sentOutMessage()} directly.
+ *
+ * <p>By living inside {@code org.playframework.netty.http} this class has the
+ * necessary package access, and exposes thin delegating methods that Scala code
+ * can call without triggering an {@link IllegalAccessError}.
+ */
+public abstract class HttpStreamsServerHandlerBridge extends HttpStreamsServerHandler {
+
+    /** Delegate to {@link HttpStreamsHandler#write}. */
+    protected void superWrite(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        super.write(ctx, msg, promise);
+    }
+
+    /** Expose {@link HttpStreamsHandler#sentOutMessage} for bookkeeping. */
+    protected void notifySentOutMessage(ChannelHandlerContext ctx) {
+        sentOutMessage(ctx);
+    }
+}

--- a/server/src/main/java/org/playframework/netty/http/HttpStreamsServerHandlerBridge.java
+++ b/server/src/main/java/org/playframework/netty/http/HttpStreamsServerHandlerBridge.java
@@ -21,22 +21,22 @@ import io.netty.channel.ChannelPromise;
 
 /**
  * Java bridge that provides access to methods on the package-private
- * {@link HttpStreamsHandler} class. Scala 3 enforces Java access modifiers at
+ * {@code HttpStreamsHandler} class. Scala 3 enforces Java access modifiers at
  * runtime so a Scala subclass in another package cannot call
  * {@code super.write()} or {@code sentOutMessage()} directly.
  *
  * <p>By living inside {@code org.playframework.netty.http} this class has the
  * necessary package access, and exposes thin delegating methods that Scala code
- * can call without triggering an {@link IllegalAccessError}.
+ * can call without triggering an {@code IllegalAccessError}.
  */
 public abstract class HttpStreamsServerHandlerBridge extends HttpStreamsServerHandler {
 
-    /** Delegate to {@link HttpStreamsHandler#write}. */
+    /** Delegate to {@code HttpStreamsHandler#write}. */
     protected void superWrite(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         super.write(ctx, msg, promise);
     }
 
-    /** Expose {@link HttpStreamsHandler#sentOutMessage} for bookkeeping. */
+    /** Expose {@code HttpStreamsHandler#sentOutMessage} for bookkeeping. */
     protected void notifySentOutMessage(ChannelHandlerContext ctx) {
         sentOutMessage(ctx);
     }

--- a/server/src/main/scala/org/http4s/netty/server/DirectStreamingServerHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/DirectStreamingServerHandler.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.netty.server
+
+import io.netty.channel.ChannelFuture
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelPromise
+import io.netty.handler.codec.http._
+import org.playframework.netty.http.HttpStreamsServerHandler
+import org.playframework.netty.http.StreamedHttpMessage
+import org.playframework.netty.http.WebSocketHttpResponse
+
+/** Extends [[HttpStreamsServerHandler]] to support direct body streaming.
+  *
+  * The parent class handles [[FullHttpMessage]] and [[StreamedHttpMessage]] on the outbound path
+  * but silently drops plain [[DefaultHttpResponse]] (headers-only) messages because its
+  * `unbufferedWrite` has no branch for them. This subclass intercepts plain [[HttpResponse]] writes
+  * to enable a direct streaming pattern: headers, body chunks ([[HttpContent]]), and
+  * [[LastHttpContent]] are written separately from the handler's fiber rather than bridging through
+  * reactive streams. This ensures body stream finalizers fire reliably.
+  *
+  * Messages that the parent already handles ([[FullHttpMessage]], [[StreamedHttpMessage]] including
+  * WebSocket upgrades) are delegated unchanged.
+  *
+  * Note: This class calls the protected `sentOutMessage(ctx)` method from
+  * [[HttpStreamsServerHandler]] to keep the parent's request/response bookkeeping correct. This is
+  * an internal API of the parent class.
+  */
+private[server] class DirectStreamingServerHandler extends HttpStreamsServerHandler {
+
+  // Whether we are currently in the direct streaming state (between headers and LastHttpContent).
+  private[this] var directStreaming: Boolean = false
+
+  // Whether the channel should be closed after the current direct-streamed response completes.
+  private[this] var closeAfterResponse: Boolean = false
+
+  // Protocol version of the most recent inbound request, used for keep-alive default logic.
+  private[this] var lastRequestVersion: HttpVersion = HttpVersion.HTTP_1_1
+
+  override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
+    msg match {
+      case req: HttpRequest => lastRequestVersion = req.protocolVersion()
+      case _ =>
+    }
+    super.channelRead(ctx, msg)
+  }
+
+  override def write(ctx: ChannelHandlerContext, msg: AnyRef, promise: ChannelPromise): Unit =
+    if (directStreaming)
+      msg match {
+        case _: LastHttpContent =>
+          directStreaming = false
+          val doClose = closeAfterResponse
+          closeAfterResponse = false
+          val _ = ctx.write(msg, promise)
+          val _ = promise.addListener { (_: ChannelFuture) =>
+            sentOutMessage(ctx)
+            if (doClose) { val _ = ctx.close() }
+          }
+
+        case _ =>
+          val _ = ctx.write(msg, promise)
+      }
+    else
+      msg match {
+        case response: HttpResponse
+            if !response.isInstanceOf[FullHttpMessage] &&
+              !response.isInstanceOf[StreamedHttpMessage] &&
+              !response.isInstanceOf[WebSocketHttpResponse] =>
+          // Plain headers-only HttpResponse: enter direct streaming mode.
+          directStreaming = true
+          closeAfterResponse = shouldClose(response)
+          val _ = ctx.write(msg, promise)
+
+        case _ =>
+          // FullHttpMessage, StreamedHttpMessage, WebSocket, or non-HttpResponse:
+          // delegate to the parent's reactive streams handling.
+          super.write(ctx, msg, promise)
+      }
+
+  /** Determine whether the connection should be closed after this response, mirroring the logic
+    * from [[HttpStreamsServerHandler]]'s `unbufferedWrite`.
+    */
+  private[this] def shouldClose(response: HttpResponse): Boolean = {
+    val connection = response.headers().get(HttpHeaderNames.CONNECTION)
+    if (lastRequestVersion.isKeepAliveDefault)
+      "close".equalsIgnoreCase(connection)
+    else
+      !"keep-alive".equalsIgnoreCase(connection)
+  }
+}

--- a/server/src/main/scala/org/http4s/netty/server/DirectStreamingServerHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/DirectStreamingServerHandler.scala
@@ -66,11 +66,12 @@ private[server] class DirectStreamingServerHandler extends HttpStreamsServerHand
           directStreaming = false
           val doClose = closeAfterResponse
           closeAfterResponse = false
-          val _ = ctx.write(msg, promise)
-          val _ = promise.addListener { (_: ChannelFuture) =>
+          ctx.write(msg, promise)
+          promise.addListener { (_: ChannelFuture) =>
             sentOutMessage(ctx)
             if (doClose) { val _ = ctx.close() }
           }
+          ()
 
         case _ =>
           val _ = ctx.write(msg, promise)

--- a/server/src/main/scala/org/http4s/netty/server/DirectStreamingServerHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/DirectStreamingServerHandler.scala
@@ -20,11 +20,11 @@ import io.netty.channel.ChannelFuture
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelPromise
 import io.netty.handler.codec.http._
-import org.playframework.netty.http.HttpStreamsServerHandler
+import org.playframework.netty.http.HttpStreamsServerHandlerBridge
 import org.playframework.netty.http.StreamedHttpMessage
 import org.playframework.netty.http.WebSocketHttpResponse
 
-/** Extends [[HttpStreamsServerHandler]] to support direct body streaming.
+/** Extends [[HttpStreamsServerHandlerBridge]] to support direct body streaming.
   *
   * The parent class handles [[FullHttpMessage]] and [[StreamedHttpMessage]] on the outbound path
   * but silently drops plain [[DefaultHttpResponse]] (headers-only) messages because its
@@ -36,11 +36,12 @@ import org.playframework.netty.http.WebSocketHttpResponse
   * Messages that the parent already handles ([[FullHttpMessage]], [[StreamedHttpMessage]] including
   * WebSocket upgrades) are delegated unchanged.
   *
-  * Note: This class calls the protected `sentOutMessage(ctx)` method from
-  * [[HttpStreamsServerHandler]] to keep the parent's request/response bookkeeping correct. This is
-  * an internal API of the parent class.
+  * We extend [[HttpStreamsServerHandlerBridge]] (a Java class in the `org.playframework.netty.http`
+  * package) rather than [[HttpStreamsServerHandler]] directly because `HttpStreamsHandler` is
+  * package-private in Java. Scala 3 enforces this at runtime and throws [[IllegalAccessError]] when
+  * `super.write()` or `sentOutMessage()` would resolve through a package-private class.
   */
-private[server] class DirectStreamingServerHandler extends HttpStreamsServerHandler {
+private[server] class DirectStreamingServerHandler extends HttpStreamsServerHandlerBridge {
 
   // Whether we are currently in the direct streaming state (between headers and LastHttpContent).
   private[this] var directStreaming: Boolean = false
@@ -68,7 +69,7 @@ private[server] class DirectStreamingServerHandler extends HttpStreamsServerHand
           closeAfterResponse = false
           ctx.write(msg, promise)
           promise.addListener { (_: ChannelFuture) =>
-            sentOutMessage(ctx)
+            notifySentOutMessage(ctx)
             if (doClose) { val _ = ctx.close() }
           }
           ()
@@ -90,7 +91,7 @@ private[server] class DirectStreamingServerHandler extends HttpStreamsServerHand
         case _ =>
           // FullHttpMessage, StreamedHttpMessage, WebSocket, or non-HttpResponse:
           // delegate to the parent's reactive streams handling.
-          super.write(ctx, msg, promise)
+          superWrite(ctx, msg, promise)
       }
 
   /** Determine whether the connection should be closed after this response, mirroring the logic

--- a/server/src/main/scala/org/http4s/netty/server/Http4sNettyHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/Http4sNettyHandler.scala
@@ -19,6 +19,7 @@ package server
 
 import cats.Defer
 import cats.effect.Async
+import cats.effect.Deferred
 import cats.effect.Resource
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
@@ -27,6 +28,7 @@ import io.netty.handler.codec.TooLongFrameException
 import io.netty.handler.codec.http._
 import io.netty.handler.timeout.IdleStateEvent
 import org.http4s.netty.server.Http4sNettyHandler.RFC7231InstantFormatter
+import org.http4s.netty.server.Http4sNettyHandler.WritabilityGate
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.log4s.getLogger
@@ -36,6 +38,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicReference
 import scala.collection.mutable.{Queue => MutableQueue}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -93,13 +96,27 @@ private[netty] abstract class Http4sNettyHandler[F[_]](disp: Dispatcher[F])(impl
 
   protected val logger = getLogger
 
-  /** Handle the given request. Note: Handle implementations fork into user ExecutionContext Returns
-    * the cleanup action along with the drain action
+  protected val writabilityGate: WritabilityGate[F] = new WritabilityGate[F]()
+
+  /** Handle the given request. Implementations write the response directly to the channel via the
+    * ChannelHandlerContext.
     */
-  def handle(
-      channel: Channel,
-      request: HttpRequest,
-      dateString: String): Resource[F, DefaultHttpResponse]
+  def handle(ctx: ChannelHandlerContext, request: HttpRequest, dateString: String): F[Unit]
+
+  override def channelWritabilityChanged(ctx: ChannelHandlerContext): Unit = {
+    if (ctx.channel().isWritable) {
+      writabilityGate.signal(disp)
+    }
+    super.channelWritabilityChanged(ctx)
+  }
+
+  override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+    // Wake any fiber suspended on the writability gate so it can proceed
+    // to writeAndFlushF, which will fail on the closed channel, triggering
+    // the normal error/finalizer path.
+    writabilityGate.signal(disp)
+    super.channelInactive(ctx)
+  }
 
   override def channelRead(ctx: ChannelHandlerContext, msg: Object): Unit = {
     logger.trace(s"channelRead: ctx = $ctx, msg = $msg")
@@ -111,10 +128,8 @@ private[netty] abstract class Http4sNettyHandler[F[_]](disp: Dispatcher[F])(impl
 
     msg match {
       case req: HttpRequest =>
-        val reqAndCleanup = handle(ctx.channel(), req, cachedDateString).allocated
-        // Start execution of the handler.
-
-        val (f, cancelRequest) = disp.unsafeToFutureCancelable(reqAndCleanup)
+        val handleF = handle(ctx, req, cachedDateString)
+        val (f, cancelRequest) = disp.unsafeToFutureCancelable(handleF)
         pendingResponses.enqueue(cancelRequest)
 
         // This attaches all writes sequentially using
@@ -122,17 +137,12 @@ private[netty] abstract class Http4sNettyHandler[F[_]](disp: Dispatcher[F])(impl
         // CTX switch the writes.
         lastResponseSent = lastResponseSent.flatMap[Unit] { _ =>
           f.transform {
-            case Success((response, cleanup)) =>
+            case Success(()) =>
               pendingResponses.dequeue()
               if (pendingResponses.isEmpty)
                 // Since we've now gone down to zero, we need to issue a
                 // read, in case we ignored an earlier read complete
                 void(ctx.read())
-              void {
-                ctx
-                  .writeAndFlush(response)
-                  .addListener((_: ChannelFuture) => disp.unsafeRunAndForget(cleanup))
-              }
               Success(())
 
             case Failure(NonFatal(e)) =>
@@ -254,6 +264,55 @@ object Http4sNettyHandler {
 
   private[netty] case object InvalidMessageException extends Exception with NoStackTrace
 
+  /** Binary suspend/resume gate that bridges Netty's `channelWritabilityChanged` event to a
+    * cats-effect fiber. Before each body chunk write, the fiber calls `awaitWritable`; if the
+    * channel is not writable (write buffer exceeds the high watermark), the fiber suspends on a
+    * `Deferred` until the channel drains below the low watermark and `signal` is called.
+    *
+    * Only one fiber writes at a time per connection (HTTP/1.1 responses are serialized by
+    * `lastResponseSent`), so a single-waiter gate is sufficient.
+    *
+    * Uses `AtomicReference` rather than `Ref[F, _]` because the gate is constructed eagerly in the
+    * handler constructor (Java-land, no `F` available).
+    */
+  private[server] final class WritabilityGate[F[_]](implicit F: Async[F]) {
+    private val waiter: AtomicReference[Deferred[F, Unit]] =
+      new AtomicReference[Deferred[F, Unit]]()
+
+    /** Suspend the calling fiber until the channel is writable. If the channel is already writable
+      * or inactive (closed), returns immediately — an inactive channel will fail on the subsequent
+      * `writeAndFlushF`, which is the correct error path.
+      */
+    def awaitWritable(ctx: ChannelHandlerContext): F[Unit] =
+      F.delay(ctx.channel().isWritable || !ctx.channel().isActive).flatMap { canProceed =>
+        if (canProceed) F.unit
+        else
+          Deferred[F, Unit].flatMap { gate =>
+            F.delay(waiter.set(gate)) *>
+              // Double-check: the channel may have become writable (or closed) between our
+              // check and setting the waiter — channelWritabilityChanged (or channelInactive)
+              // would have fired finding no waiter. Re-check catches this race.
+              F.delay(ctx.channel().isWritable || !ctx.channel().isActive).flatMap { canProceedNow =>
+                if (canProceedNow) {
+                  // Clear the waiter we just set — nobody will signal it.
+                  F.delay { val _ = waiter.compareAndSet(gate, null) }
+                } else
+                  gate.get
+              }
+          }
+      }
+
+    /** Complete the pending waiter (if any), waking the suspended fiber. Called from the Netty
+      * event loop thread via `channelWritabilityChanged`.
+      */
+    def signal(disp: Dispatcher[F]): Unit = {
+      val gate = waiter.getAndSet(null)
+      if (gate != null) {
+        disp.unsafeRunAndForget(gate.complete(()))
+      }
+    }
+  }
+
   private class WebsocketHandler[F[_]](
       appFn: WebSocketBuilder2[F] => HttpResource[F],
       serviceErrorHandler: ServiceErrorHandler[F],
@@ -267,29 +326,52 @@ object Http4sNettyHandler {
     private[this] val converter: ServerNettyModelConversion[F] = new ServerNettyModelConversion[F]
 
     override def handle(
-        channel: Channel,
+        ctx: ChannelHandlerContext,
         request: HttpRequest,
         dateString: String
-    ): Resource[F, DefaultHttpResponse] =
-      Resource.eval(WebSocketBuilder2[F]).flatMap { b =>
-        val app = appFn(b)
-        logger.trace("Http request received by netty: " + request)
-        converter
-          .fromNettyRequest(channel, request)
-          .flatMap { req =>
-            val pf = serviceErrorHandler(req)
-            D.defer(app(req))
-              .recoverWith { case t if pf.isDefinedAt(t) => Resource.eval(pf(t)) }
-              .flatMap(
-                converter.toNettyResponseWithWebsocket(
-                  channel,
-                  b.webSocketKey,
-                  req,
-                  _,
-                  dateString,
-                  maxWSPayloadLength))
-          }
-      }
+    ): F[Unit] =
+      Resource
+        .eval(WebSocketBuilder2[F])
+        .flatMap { b =>
+          val app = appFn(b)
+          logger.trace("Http request received by netty: " + request)
+          converter
+            .fromNettyRequest(ctx.channel(), request)
+            .evalMap { req =>
+              val pf = serviceErrorHandler(req)
+              // The app is cancelable (via poll) so that idle timeouts
+              // can interrupt slow handlers. Once the app returns a
+              // response, the uncancelable boundary ensures the Resource
+              // finalizer fires — critical for HttpResource routes like:
+              //   client.run(backendReq)  // Resource release = connection release
+              // Without uncancelable, cancellation between .allocated and
+              // the F.guarantee would lose `release`, leaking upstream
+              // connections. writeResponseWithWebsocket is also internally
+              // uncancelable (writeBodyResponse always drains the body to
+              // fire stream finalizers), so it completes even if the
+              // channel is already closed.
+              F.uncancelable { poll =>
+                poll(
+                  D.defer(app(req))
+                    .recoverWith { case t if pf.isDefinedAt(t) => Resource.eval(pf(t)) }
+                    .allocated
+                ).flatMap { case (response, release) =>
+                  F.guarantee(
+                    converter.writeResponseWithWebsocket(
+                      b.webSocketKey,
+                      ctx,
+                      req,
+                      response,
+                      dateString,
+                      maxWSPayloadLength,
+                      writabilityGate.awaitWritable),
+                    release
+                  )
+                }
+              }
+            }
+        }
+        .use_
   }
 
   def websocket[F[_]: Async](

--- a/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
@@ -32,7 +32,6 @@ import org.http4s.netty.HttpResource
 import org.http4s.netty.void
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.websocket.WebSocketBuilder2
-import org.playframework.netty.http.HttpStreamsServerHandler
 
 private object NettyPipelineHelpers {
 
@@ -96,7 +95,7 @@ private object NettyPipelineHelpers {
           new WebSocketServerCompressionHandler(config.wsMaxFrameLength)))
     }
     pipeline.addLast("websocket-aggregator", new WebSocketFrameAggregator(config.wsMaxFrameLength))
-    pipeline.addLast("serverStreamsHandler", new HttpStreamsServerHandler())
+    pipeline.addLast("serverStreamsHandler", new DirectStreamingServerHandler())
     pipeline.addLast(
       "http4s",
       Http4sNettyHandler

--- a/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
+++ b/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
@@ -322,7 +322,7 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
     )
     httpResponse.headers.foreach(appendSomeToNetty(_, response.headers()))
     if (httpRequest.method == Method.HEAD) {
-      addHeadResponseHeaders(httpResponse, minorIs0, response.headers())
+      addHeadResponseHeaders(httpResponse, response.headers())
     }
     addDateAndConnectionHeaders(response.headers(), httpRequest, dateString, minorIs0)
     writeAndFlushF(ctx, response) *>

--- a/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
+++ b/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
@@ -342,7 +342,14 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
       dateString: String,
       maxPayloadLength: Int
   ): F[Unit] =
-    toWSResponse(ctx, httpRequest, httpResponse, httpVersion, wsContext, dateString, maxPayloadLength)
+    toWSResponse(
+      ctx,
+      httpRequest,
+      httpResponse,
+      httpVersion,
+      wsContext,
+      dateString,
+      maxPayloadLength)
       .use { resp =>
         resp match {
           case _: DefaultWebSocketHttpResponse =>

--- a/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
+++ b/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
@@ -26,11 +26,16 @@ import fs2.Stream
 import fs2.interop.flow.StreamSubscriberWrapper
 import io.netty.buffer.Unpooled
 import io.netty.channel.Channel
+import io.netty.channel.ChannelFuture
 import io.netty.channel.ChannelFutureListener
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.http.DefaultFullHttpResponse
+import io.netty.handler.codec.http.DefaultHttpContent
 import io.netty.handler.codec.http.DefaultHttpResponse
 import io.netty.handler.codec.http.HttpHeaders
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http.HttpVersion
+import io.netty.handler.codec.http.LastHttpContent
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame
 import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame
@@ -41,11 +46,14 @@ import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory
 import io.netty.handler.codec.http.websocketx.{WebSocketFrame => WSFrame}
 import org.http4s.Header
+import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Response
 import org.http4s.internal.tls._
 import org.http4s.netty.NettyModelConversion
 import org.http4s.netty.NettyModelConversion.bytebufToArray
+import org.http4s.netty.NettyModelConversion.chunkToBytebuf
+import org.http4s.netty.NettyModelConversion.resolveHttpVersion
 import org.http4s.netty.server.websocket.ZeroCopyBinaryText
 import org.http4s.server.SecureSession
 import org.http4s.server.ServerRequestKeys
@@ -54,7 +62,6 @@ import org.http4s.websocket.WebSocketContext
 import org.http4s.websocket.WebSocketFrame
 import org.http4s.websocket.WebSocketFrame._
 import org.http4s.websocket.WebSocketSeparatePipe
-import org.http4s.{HttpVersion => HV}
 import org.playframework.netty.http.DefaultWebSocketHttpResponse
 import org.reactivestreams.FlowAdapters
 import org.reactivestreams.Processor
@@ -69,6 +76,7 @@ import javax.net.ssl.SSLEngine
 
 private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F])
     extends NettyModelConversion[F] {
+  private val logger = org.log4s.getLogger
   override protected def requestAttributes(
       optionalSslEngine: Option[SSLEngine],
       channel: Channel): Vault =
@@ -90,41 +98,6 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
           }
       )
 
-  /** Create a Netty response from the result */
-  def toNettyResponseWithWebsocket(
-      channel: Channel,
-      key: Key[WebSocketContext[F]],
-      httpRequest: Request[F],
-      httpResponse: Response[F],
-      dateString: String,
-      maxPayloadLength: Int
-  ): Resource[F, DefaultHttpResponse] = {
-    // Http version is 1.0. We can assume it's most likely not.
-    var minorIs0 = false
-    val httpVersion: HttpVersion =
-      if (httpRequest.httpVersion == HV.`HTTP/1.1`)
-        HttpVersion.HTTP_1_1
-      else if (httpRequest.httpVersion == HV.`HTTP/1.0`) {
-        minorIs0 = true
-        HttpVersion.HTTP_1_0
-      } else
-        HttpVersion.valueOf(httpRequest.httpVersion.renderString)
-
-    httpResponse.attributes.lookup(key) match {
-      case Some(wsContext) if !minorIs0 =>
-        toWSResponse(
-          channel,
-          httpRequest,
-          httpResponse,
-          httpVersion,
-          wsContext,
-          dateString,
-          maxPayloadLength)
-      case _ =>
-        toNonWSResponse(httpRequest, httpResponse, httpVersion, dateString, minorIs0)
-    }
-  }
-
   /** Render a websocket response, or if the handshake fails eventually, an error Note: This
     * function is only invoked for http 1.1, as websockets aren't supported for http 1.0.
     *
@@ -140,7 +113,7 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
     * @return
     */
   private[this] def toWSResponse(
-      channel: Channel,
+      channel: ChannelHandlerContext,
       httpRequest: Request[F],
       httpResponse: Response[F],
       httpVersion: HttpVersion,
@@ -228,6 +201,174 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
               toNonWSResponse(httpRequest, res, httpVersion, dateString, minorVersionIs0 = true)))
     } else
       toNonWSResponse(httpRequest, httpResponse, httpVersion, dateString, minorVersionIs0 = true)
+
+  /** Write a response (with possible WS upgrade) directly to the channel. Compiles the response
+    * body stream in the handler's fiber rather than bridging through reactive streams, ensuring
+    * body stream finalizers fire.
+    */
+  def writeResponseWithWebsocket(
+      key: Key[WebSocketContext[F]],
+      ctx: ChannelHandlerContext,
+      httpRequest: Request[F],
+      httpResponse: Response[F],
+      dateString: String,
+      maxPayloadLength: Int,
+      awaitWritable: ChannelHandlerContext => F[Unit]
+  ): F[Unit] = {
+    val (httpVersion, minorIs0) = resolveHttpVersion(httpRequest.httpVersion)
+
+    httpResponse.attributes.lookup(key) match {
+      case Some(wsContext) if !minorIs0 =>
+        writeWebSocketResponse(
+          ctx,
+          httpRequest,
+          httpResponse,
+          httpVersion,
+          wsContext,
+          dateString,
+          maxPayloadLength)
+      case _ =>
+        writeResponse(
+          ctx,
+          httpRequest,
+          httpResponse,
+          httpVersion,
+          dateString,
+          minorIs0,
+          awaitWritable)
+    }
+  }
+
+  private def writeResponse(
+      ctx: ChannelHandlerContext,
+      httpRequest: Request[F],
+      httpResponse: Response[F],
+      httpVersion: HttpVersion,
+      dateString: String,
+      minorIs0: Boolean,
+      awaitWritable: ChannelHandlerContext => F[Unit]
+  ): F[Unit] =
+    if (httpResponse.status.isEntityAllowed && httpRequest.method != Method.HEAD)
+      writeBodyResponse(
+        ctx,
+        httpRequest,
+        httpResponse,
+        httpVersion,
+        dateString,
+        minorIs0,
+        awaitWritable)
+    else
+      writeFullResponse(ctx, httpRequest, httpResponse, httpVersion, dateString, minorIs0)
+
+  private def writeBodyResponse(
+      ctx: ChannelHandlerContext,
+      httpRequest: Request[F],
+      httpResponse: Response[F],
+      httpVersion: HttpVersion,
+      dateString: String,
+      minorIs0: Boolean,
+      awaitWritable: ChannelHandlerContext => F[Unit]
+  ): F[Unit] = {
+    val headersResponse =
+      new DefaultHttpResponse(httpVersion, HttpResponseStatus.valueOf(httpResponse.status.code))
+    httpResponse.headers.foreach(appendSomeToNetty(_, headersResponse.headers()))
+    addTransferOrContentLengthHeaders(httpResponse.headers, minorIs0, headersResponse.headers())
+    addDateAndConnectionHeaders(headersResponse.headers(), httpRequest, dateString, minorIs0)
+
+    // The body MUST be compiled (drained) so that stream finalizers fire —
+    // e.g., onFinalize callbacks that return connections to upstream pools.
+    // The entire drain is uncancelable to prevent cancellation from firing
+    // before compile.drain opens the stream scope (which would skip finalizers).
+    // When the channel is dead, the first chunk write fails immediately,
+    // compile.drain errors, and finalizers fire — so the uncancelable window
+    // is short in practice.
+    F.uncancelable { _ =>
+      writeAndFlushF(ctx, headersResponse).attempt.flatMap {
+        case Right(()) =>
+          F.guarantee(
+            httpResponse.body.chunks
+              .evalMap { chunk =>
+                awaitWritable(ctx) *>
+                  writeAndFlushF(ctx, new DefaultHttpContent(chunkToBytebuf(chunk)))
+              }
+              .compile
+              .drain,
+            writeAndFlushF(ctx, LastHttpContent.EMPTY_LAST_CONTENT).handleError(_ => ())
+          ).handleErrorWith { e =>
+            F.delay(logger.debug(e)("Error writing response body, closing channel")) *>
+              F.delay(ctx.close()).void
+          }
+        case Left(e) =>
+          // Headers write failed (channel already closed). Still drain the body
+          // so that stream finalizers fire (e.g., returning connections to pools).
+          httpResponse.body.compile.drain.handleError(_ => ()) *>
+            F.delay(logger.debug(e)("Channel closed before headers could be sent")) *>
+            F.delay(ctx.close()).void
+      }
+    }
+  }
+
+  private def writeFullResponse(
+      ctx: ChannelHandlerContext,
+      httpRequest: Request[F],
+      httpResponse: Response[F],
+      httpVersion: HttpVersion,
+      dateString: String,
+      minorIs0: Boolean
+  ): F[Unit] = {
+    val response = new DefaultFullHttpResponse(
+      httpVersion,
+      HttpResponseStatus.valueOf(httpResponse.status.code)
+    )
+    httpResponse.headers.foreach(appendSomeToNetty(_, response.headers()))
+    if (httpRequest.method == Method.HEAD) {
+      addHeadResponseHeaders(httpResponse, minorIs0, response.headers())
+    }
+    addDateAndConnectionHeaders(response.headers(), httpRequest, dateString, minorIs0)
+    writeAndFlushF(ctx, response) *>
+      // Drain the body so that stream finalizers fire even for responses
+      // without entity bodies (HEAD, 204, 304, etc.). In proxy patterns
+      // the body may carry onFinalize callbacks that return connections
+      // to upstream pools — these must fire even when no body is written.
+      httpResponse.body.compile.drain.handleError(_ => ())
+  }
+
+  private def writeWebSocketResponse(
+      ctx: ChannelHandlerContext,
+      httpRequest: Request[F],
+      httpResponse: Response[F],
+      httpVersion: HttpVersion,
+      wsContext: WebSocketContext[F],
+      dateString: String,
+      maxPayloadLength: Int
+  ): F[Unit] =
+    toWSResponse(ctx, httpRequest, httpResponse, httpVersion, wsContext, dateString, maxPayloadLength)
+      .use { resp =>
+        resp match {
+          case _: DefaultWebSocketHttpResponse =>
+            // The WS handshake is performed by HttpStreamsServerHandler which
+            // never completes the original ChannelPromise, so we must use
+            // fire-and-forget here instead of writeAndFlushF.
+            // Keep the Resource alive until the channel closes so the WS
+            // reactive-streams processor continues to run.
+            F.delay { val _ = ctx.writeAndFlush(resp) } *>
+              F.async_[Unit] { cb =>
+                val _ =
+                  ctx.channel().closeFuture().addListener((_: ChannelFuture) => cb(Right(())))
+              }
+          case _ =>
+            // Non-WS fallback (handshake failed): write via normal path.
+            writeAndFlushF(ctx, resp)
+        }
+      }
+
+  private def writeAndFlushF(ctx: ChannelHandlerContext, msg: AnyRef): F[Unit] =
+    F.async_[Unit] { cb =>
+      val _ = ctx.writeAndFlush(msg).addListener { (f: ChannelFuture) =>
+        if (f.isSuccess) cb(Right(()))
+        else cb(Left(f.cause()))
+      }
+    }
 
   private[this] def appendAllToNetty(header: Header.Raw, nettyHeaders: HttpHeaders) = {
     nettyHeaders.add(header.name.toString, header.value)

--- a/server/src/test/scala/org/http4s/netty/server/HeaderConversionTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/HeaderConversionTest.scala
@@ -34,7 +34,6 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
 
 class HeaderConversionTest extends IOSuite {
 
@@ -111,7 +110,7 @@ class HeaderConversionTest extends IOSuite {
         .build()
       val response = jdkClient.send(request, HttpResponse.BodyHandlers.discarding())
 
-      val teHeaders = response.headers().allValues("Transfer-Encoding").asScala.toList
+      val teHeaders = response.headers().allValues("Transfer-Encoding")
       assert(
         teHeaders.isEmpty,
         s"Transfer-Encoding header should not be present on HEAD response, got: $teHeaders"

--- a/server/src/test/scala/org/http4s/netty/server/ProxyReleaseTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/ProxyReleaseTest.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.netty.server
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.implicits._
+import fs2.Stream
+import munit.catseffect.IOFixture
+import org.http4s.HttpRoutes
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Response
+import org.http4s.Status
+import org.http4s.client.Client
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import org.http4s.netty.client.NettyClientBuilder
+import org.http4s.server.Server
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.Socket
+import scala.concurrent.duration._
+
+/** Tests that the proxy pattern works correctly with HttpResource.
+  *
+  * The proxy uses `withHttpWebSocketResource` so the route returns `Resource[IO, Response[IO]]`
+  * directly — the Resource finalizer IS the upstream connection release. The proxy's upstream
+  * client has a pool size of 1, so if any request's finalizer doesn't fire, the next request
+  * deadlocks waiting for a connection.
+  *
+  * Without direct body streaming, the reactive-streams bridge doesn't drain the body when
+  * downstream clients don't read it, so the Resource finalizer never fires and the pool exhausts
+  * under load.
+  */
+class ProxyReleaseTest extends IOSuite {
+  val setup: IOFixture[(Server, Client[IO])] = resourceFixture(
+    for {
+      // Backend server
+      backend <- NettyServerBuilder[IO]
+        .withHttpApp(
+          HttpRoutes
+            .of[IO] {
+              case GET -> Root / "data" =>
+                Ok(Stream.emits("hello from backend".getBytes).covary[IO])
+              case HEAD -> Root / "data" =>
+                Ok(Stream.emits("hello from backend".getBytes).covary[IO])
+            }
+            .orNotFound
+        )
+        .withNioTransport
+        .withoutBanner
+        .bindAny()
+        .resource
+
+      // Proxy upstream client: pool size 1 so leaks cause deadlocks.
+      proxyClient <- NettyClientBuilder[IO]
+        .withMaxConnectionsPerKey(1)
+        .withNioTransport
+        .resource
+
+      // Proxy server using HttpResource — the Resource wraps the upstream
+      // client connection, so its finalizer returns the connection to the pool.
+      proxy <- {
+        val proxyRoutes: Request[IO] => Resource[IO, Response[IO]] = { req =>
+          val backendUri = backend.baseUri / "data"
+          proxyClient.run(Request[IO](method = req.method, uri = backendUri))
+        }
+        NettyServerBuilder[IO]
+          .withHttpWebSocketResource(_ => proxyRoutes)
+          .withNioTransport
+          .withoutBanner
+          .bindAny()
+          .resource
+      }
+
+      // Downstream client
+      client <- NettyClientBuilder[IO].withNioTransport.resource
+    } yield (proxy, client),
+    "setup"
+  )
+
+  test("body-consumed requests release connections") {
+    val (proxy, client) = setup()
+    val uri = proxy.baseUri / "proxy"
+
+    client.expect[String](uri).map(body => assertEquals(body, "hello from backend"))
+  }
+
+  test("unconsumed body releases connection under load") {
+    val (proxy, client) = setup()
+    val uri = proxy.baseUri / "proxy"
+
+    // 40 concurrent, 200 total — never consume the body.
+    // Pool size is 1: if finalizers don't fire the pool exhausts
+    // after 1 request and the rest time out.
+    Stream
+      .emits(1 to 200)
+      .covary[IO]
+      .parEvalMap(40) { _ =>
+        client
+          .run(Request[IO](uri = uri))
+          .use(resp => IO(assertEquals(resp.status, Status.Ok)))
+          .timeout(10.seconds)
+      }
+      .compile
+      .drain
+  }
+
+  test("HEAD requests drain body and release connections") {
+    val (proxy, client) = setup()
+    val uri = proxy.baseUri / "proxy"
+
+    // HEAD goes through writeFullResponse which must drain the body stream
+    // so the Resource finalizer fires. Pool size 1 means the second request
+    // deadlocks if the first doesn't release.
+    // We accept Ok or InternalServerError because the Netty client can
+    // intermittently mishandle HEAD responses with Content-Length headers.
+    // The key assertion is no timeout — a leaked upstream connection with
+    // pool size 1 would deadlock, not produce a status error.
+    (1 to 5).toList.traverse_ { _ =>
+      client
+        .run(Request[IO](Method.HEAD, uri))
+        .use(resp =>
+          IO(
+            assert(
+              resp.status == Status.Ok || resp.status == Status.InternalServerError,
+              s"Unexpected status: ${resp.status}")))
+        .recover { case _: java.nio.channels.ClosedChannelException => () }
+        .timeout(5.seconds)
+    }
+  }
+
+  test("client disconnect mid-body still releases connection") {
+    val (proxy, _) = setup()
+
+    // Open a raw socket, send a request for the proxy, read the status line,
+    // then close without reading the body. The server must still finalize
+    // the body stream so the upstream connection returns to the pool.
+    // Do it 3 times sequentially — with pool size 1, the second request
+    // hangs if the first didn't release.
+    (1 to 3).toList.traverse_ { _ =>
+      IO.blocking {
+        val host = proxy.baseUri.host.get.renderString
+        val port = proxy.baseUri.port.get
+        val socket = new Socket(host, port)
+        try {
+          socket.setSoTimeout(5000)
+          val out = socket.getOutputStream
+          val in = new BufferedReader(new InputStreamReader(socket.getInputStream))
+          out.write("GET /proxy HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".getBytes)
+          out.flush()
+          val statusLine = in.readLine()
+          assert(
+            statusLine != null && statusLine.contains("200"),
+            s"Expected 200 but got: $statusLine")
+        } finally
+          socket.close()
+      } *> IO.sleep(500.millis) // allow server to detect close and finalize
+    }
+  }
+}


### PR DESCRIPTION
This is my attempt at getting direct streaming (fixing #908), but I didn't try to go all the way to get rid of the reactive-streams stuff. If you run the ProxyReleaseTest against series/0.7 they will fail, and they succeed here. Let me know what you think.

## Summary

  - Replace the reactive-streams bridge with direct body streaming from the handler's cats-effect fiber, ensuring response body stream finalizers fire reliably in all cases (unconsumed body, HEAD, client disconnect
  mid-body)
  - Add write backpressure via a WritabilityGate that suspends the streaming fiber when Netty's outbound buffer exceeds its high watermark, preventing unbounded memory growth for slow clients
  - Fix same issue fixed by #896, but instead opt for the simpler approach of just not writing the `Transfer-Encoding` header.

### Direct streaming
  `handle` now returns `F[Unit]` instead of `Resource[F, DefaultHttpResponse]`. Response headers, body chunks, and LastHttpContent are written directly to the channel from the handler's fiber via `writeAndFlushF`, rather than being handed off as a `StreamedHttpMessage` for the reactive-streams bridge to publish. This guarantees compile.drain runs on the  body stream so finalizers (e.g., returning upstream connections to pools in proxy patterns) always fire — even when the downstream client never reads the body.

`DirectStreamingServerHandler` intercepts plain `HttpResponse` writes (headers-only, not `FullHttpMessage` or `StreamedHttpMessage`) and enter a direct streaming mode where subsequent writes pass straight through. `WebSocket` upgrade responses still delegate to the parent's reactive-streams handling.

### Backpressure
  Before each body chunk write, the fiber calls `awaitWritable(ctx)`. If Netty's write buffer has exceeded the 64KB high watermark, the fiber suspends on a Deferred until it is signaled that the buffer has drained below the 32KB low watermark. A double-check after setting the waiter guards against the race where writability changes between the check and the suspend. `channelInactive` also signals the gate so a fiber blocked inside the uncancelable body drain wakes up and hits the normal `writeAndFlushF` failure path when the channel closes.

### Misc
  Inlined header-writing logic (date/connection headers, HEAD response headers, transfer-encoding/content-length) was extracted into protected methods so ServerNettyModelConversion can reuse them in the direct streaming write paths without duplicating code.