### PR TITLE
Ensure no double subscribe on 0.7

### DIFF
--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -223,13 +223,17 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
         }
       case streamed: StreamedHttpMessage =>
         val isDrained = new AtomicBoolean(false)
+        val subscribed = new AtomicBoolean(false)
         val stream =
           Stream
-            .fromPublisher[F](FlowAdapters.toFlowPublisher(streamed), 1)
+            .eval(F.delay(subscribed.set(true)))
+            .flatMap(_ =>
+              Stream
+                .fromPublisher[F](FlowAdapters.toFlowPublisher(streamed), 1))
             .flatMap(c =>
               Stream.chunk(Chunk.array(NettyModelConversion.bytebufToArray(c.content()))))
             .onFinalize(F.delay(void(isDrained.compareAndSet(false, true))))
-        (stream, drainBody(_, stream, isDrained))
+        (stream, drainBody(_, stream, isDrained, subscribed))
       case _ => (Stream.empty.covary[F], _ => F.unit)
     }
 
@@ -415,11 +419,21 @@ object NettyModelConversion {
 
   /** Return an action that will drain the channel stream in the case that it wasn't drained.
     */
-  private[netty] def drainBody[F[_]](c: Channel, f: Stream[F, Byte], isDrained: AtomicBoolean)(
-      implicit F: Async[F]): F[Unit] =
+  private[netty] def drainBody[F[_]](
+      c: Channel,
+      f: Stream[F, Byte],
+      isDrained: AtomicBoolean,
+      subscribed: AtomicBoolean)(implicit F: Async[F]): F[Unit] =
     F.delay {
       if (isDrained.compareAndSet(false, true)) {
-        if (c.isOpen) {
+        if (subscribed.get()) {
+          // The stream was already subscribed to (body partially consumed).
+          // HandlerPublisher only supports one subscriber, so we cannot
+          // re-subscribe to drain. Close the connection instead. The
+          // remaining request bytes would corrupt the next request anyway.
+          logger.info("Request body not fully drained but already subscribed. Closing connection")
+          F.delay(c.close()).void
+        } else if (c.isOpen) {
           logger.info("Response body not drained to completion. Draining and closing connection")
           // Drain the stream regardless. Some bytebufs often
           // Remain in the buffers. Draining them solves this issue

--- a/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.netty.server
+
+import cats.effect.IO
+import io.netty.buffer.Unpooled
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.http.DefaultHttpContent
+import io.netty.handler.codec.http.HttpContent
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpVersion
+import munit.CatsEffectSuite
+import org.http4s.netty.NettyModelConversion
+import org.playframework.netty.http.DefaultStreamedHttpRequest
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.duration._
+
+/** When a request body stream is actively being consumed and the request is released, `drainBody`
+  * must not attempt a second subscription to the single-subscriber `HandlerPublisher`.
+  */
+class DrainBodyDoubleSubscribeTest extends CatsEffectSuite {
+
+  /** A reactive-streams Publisher that only supports one subscriber, matching HandlerPublisher When
+    * completeAfterEmit = true - calls onComplete after emitting one chunk, simulating a small
+    * finished upload. When completeAfterEmit = false - emits one chunk then blocks forever,
+    * simulating a slow/large upload in progress.
+    */
+  private class SingleSubscriberPublisher(completeAfterEmit: Boolean)
+      extends Publisher[HttpContent] {
+    private val hasSubscriber = new AtomicBoolean(false)
+
+    override def subscribe(s: Subscriber[_ >: HttpContent]): Unit =
+      if (!hasSubscriber.compareAndSet(false, true)) {
+        s.onError(new IllegalStateException("This publisher only supports one subscriber"))
+      } else {
+        s.onSubscribe(new Subscription {
+          private val emitted = new AtomicBoolean(false)
+          override def request(n: Long): Unit =
+            if (emitted.compareAndSet(false, true)) {
+              val content =
+                new DefaultHttpContent(Unpooled.wrappedBuffer(Array.fill(64)(42.toByte)))
+              s.onNext(content)
+              if (completeAfterEmit) s.onComplete()
+            }
+          override def cancel(): Unit = ()
+        })
+      }
+  }
+
+  test(
+    "ensure releasing while body is being consumed does not double subscribe"
+  ) {
+    val publisher = new SingleSubscriberPublisher(false)
+    val channel = new EmbeddedChannel()
+    val request = new DefaultStreamedHttpRequest(
+      HttpVersion.HTTP_1_1,
+      HttpMethod.PUT,
+      "/test",
+      publisher
+    )
+    val conversion = new NettyModelConversion[IO]
+
+    // Use .allocated so we control exactly when the drainBody fires.
+    conversion.fromNettyRequest(channel, request).allocated.flatMap { case (req, release) =>
+      // The fiber subscribes to the publisher and blocks waiting for more data (which never arrives).
+      // This keeps the subscription active when we manually trigger release below.
+      req.body.compile.drain.start.flatMap { fiber =>
+        // Ensure the fiber has time to subscribe
+        IO.sleep(200.millis) *>
+          // Manually release
+          release.attempt.flatMap { result =>
+            // clean up the blocked fiber
+            fiber.cancel *>
+              IO {
+                assert(
+                  result.isRight,
+                  s"Resource release should not throw, but got: ${result}"
+                )
+              }
+          }
+      }
+    }
+  }
+
+  test("ensure releasing request Resource when body was never consumed drains without error") {
+    val publisher = new SingleSubscriberPublisher(completeAfterEmit = true)
+    val channel = new EmbeddedChannel()
+    val request = new DefaultStreamedHttpRequest(
+      HttpVersion.HTTP_1_1,
+      HttpMethod.PUT,
+      "/test",
+      publisher
+    )
+    val conversion = new NettyModelConversion[IO]
+
+    // Body is never consumed. drainBody should subscribe to drain.
+    conversion.fromNettyRequest(channel, request).allocated.flatMap { case (_, release) =>
+      release.timeout(5.seconds).attempt.map { result =>
+        assert(result.isRight, s"Resource release should not throw, but got: ${result}")
+      }
+    }
+  }
+}

--- a/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
@@ -38,10 +38,10 @@ import scala.concurrent.duration._
   */
 class DrainBodyDoubleSubscribeTest extends CatsEffectSuite {
 
-  /** A reactive-streams Publisher that only supports one subscriber, matching HandlerPublisher When
-    * completeAfterEmit = true - calls onComplete after emitting one chunk, simulating a small
-    * finished upload. When completeAfterEmit = false - emits one chunk then blocks forever,
-    * simulating a slow/large upload in progress.
+  /** A reactive-streams Publisher that only supports one subscriber, matching HandlerPublisher.
+    * When completeAfterEmit = true - calls onComplete after emitting one chunk, simulating a small
+    * finished upload. When completeAfterEmit = false - never emits, simulating a slow/large upload
+    * in progress.
     */
   private class SingleSubscriberPublisher(completeAfterEmit: Boolean)
       extends Publisher[HttpContent] {
@@ -49,16 +49,21 @@ class DrainBodyDoubleSubscribeTest extends CatsEffectSuite {
 
     override def subscribe(s: Subscriber[_ >: HttpContent]): Unit =
       if (!hasSubscriber.compareAndSet(false, true)) {
+        // Per reactive-streams spec, onSubscribe must be called before onError.
+        s.onSubscribe(new Subscription {
+          override def request(n: Long): Unit = ()
+          override def cancel(): Unit = ()
+        })
         s.onError(new IllegalStateException("This publisher only supports one subscriber"))
       } else {
         s.onSubscribe(new Subscription {
           private val emitted = new AtomicBoolean(false)
           override def request(n: Long): Unit =
-            if (emitted.compareAndSet(false, true)) {
+            if (completeAfterEmit && emitted.compareAndSet(false, true)) {
               val content =
                 new DefaultHttpContent(Unpooled.wrappedBuffer(Array.fill(64)(42.toByte)))
               s.onNext(content)
-              if (completeAfterEmit) s.onComplete()
+              s.onComplete()
             }
           override def cancel(): Unit = ()
         })


### PR DESCRIPTION
Fixes #932. The issue is that if the reader stops in the middle of the stream the release function tries to subscribe, which fails. Instead we keep track of if there is already a subscriber and if there is just close the connection.