### PR TITLE
Fix illegal start-line of http request

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,13 @@ lazy val server = project
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.http4s.netty.server.Http4sNettyHandler#WebsocketHandler.this"),
       ProblemFilters.exclude[MissingTypesProblem](
-        "org.http4s.netty.server.NegotiationHandler$Config$")
+        "org.http4s.netty.server.NegotiationHandler$Config$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.netty.server.NettyPipelineHelpers.buildHttp1Pipeline"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.netty.server.NettyPipelineHelpers.buildHttp2Pipeline"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.netty.server.PriorKnowledgeDetectionHandler.this")
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,8 @@ lazy val server = project
         "org.http4s.netty.server.NegotiationHandler#Config.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.http4s.netty.server.NettyServerBuilder.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.netty.server.Http4sNettyHandler#WebsocketHandler.this"),
       ProblemFilters.exclude[MissingTypesProblem](
         "org.http4s.netty.server.NegotiationHandler$Config$")
     )

--- a/server/src/main/scala/org/http4s/netty/server/Http4sNettyHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/Http4sNettyHandler.scala
@@ -27,6 +27,8 @@ import io.netty.handler.codec.TooLongFrameException
 import io.netty.handler.codec.http._
 import io.netty.handler.timeout.IdleStateEvent
 import org.http4s.HttpApp
+import org.http4s.ParseFailure
+import org.http4s.Response
 import org.http4s.netty.server.Http4sNettyHandler.RFC7231InstantFormatter
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.websocket.WebSocketBuilder2
@@ -258,6 +260,7 @@ object Http4sNettyHandler {
   private class WebsocketHandler[F[_]](
       appFn: WebSocketBuilder2[F] => HttpApp[F],
       serviceErrorHandler: ServiceErrorHandler[F],
+      requestLineParseErrorHandler: Throwable => F[Response[F]],
       maxWSPayloadLength: Int,
       dispatcher: Dispatcher[F]
   )(implicit
@@ -289,14 +292,27 @@ object Http4sNettyHandler {
                   dateString,
                   maxWSPayloadLength))
           }
+          .handleErrorWith {
+            case e: ParseFailure =>
+              Resource
+                .eval(requestLineParseErrorHandler(e))
+                .flatMap(converter.toSimpleNettyResponse(_))
+            case e => Resource.eval(F.raiseError(e))
+          }
       }
   }
 
   def websocket[F[_]: Async](
       app: WebSocketBuilder2[F] => HttpApp[F],
       serviceErrorHandler: ServiceErrorHandler[F],
+      requestLineParseErrorHandler: Throwable => F[Response[F]],
       maxWSPayloadLength: Int,
       dispatcher: Dispatcher[F]
   ): Http4sNettyHandler[F] =
-    new WebsocketHandler[F](app, serviceErrorHandler, maxWSPayloadLength, dispatcher)
+    new WebsocketHandler[F](
+      app,
+      serviceErrorHandler,
+      requestLineParseErrorHandler,
+      maxWSPayloadLength,
+      dispatcher)
 }

--- a/server/src/main/scala/org/http4s/netty/server/NegotiationHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NegotiationHandler.scala
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.ssl.ApplicationProtocolNames
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler
 import org.http4s.HttpApp
+import org.http4s.Response
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.websocket.WebSocketBuilder2
 
@@ -32,6 +33,7 @@ private[server] class NegotiationHandler[F[_]: Async](
     config: NegotiationHandler.Config,
     httpApp: WebSocketBuilder2[F] => HttpApp[F],
     serviceErrorHandler: ServiceErrorHandler[F],
+    requestLineParseErrorHandler: Throwable => F[Response[F]],
     dispatcher: Dispatcher[F]
 ) extends ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
   override def configurePipeline(ctx: ChannelHandlerContext, protocol: String): Unit =
@@ -42,6 +44,7 @@ private[server] class NegotiationHandler[F[_]: Async](
           config,
           httpApp,
           serviceErrorHandler,
+          requestLineParseErrorHandler,
           dispatcher)
 
       case ApplicationProtocolNames.HTTP_1_1 =>
@@ -50,6 +53,7 @@ private[server] class NegotiationHandler[F[_]: Async](
           config,
           httpApp,
           serviceErrorHandler,
+          requestLineParseErrorHandler,
           dispatcher)
 
       case _ => throw new IllegalStateException(s"Protocol: $protocol not supported")

--- a/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NettyPipelineHelpers.scala
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http2.Http2MultiplexHandler
 import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec
 import io.netty.handler.timeout.IdleStateHandler
 import org.http4s.HttpApp
+import org.http4s.Response
 import org.http4s.netty.void
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.websocket.WebSocketBuilder2
@@ -41,6 +42,7 @@ private object NettyPipelineHelpers {
       config: NegotiationHandler.Config,
       httpApp: WebSocketBuilder2[F] => HttpApp[F],
       serviceErrorHandler: ServiceErrorHandler[F],
+      requestLineParseErrorHandler: Throwable => F[Response[F]],
       dispatcher: Dispatcher[F]): Unit = void {
     // H2, being a multiplexed protocol, needs to always be reading events in case
     // it needs to close a stream, etc. Flow control is provided by the protocol itself.
@@ -52,7 +54,13 @@ private object NettyPipelineHelpers {
         new Http2MultiplexHandler(new ChannelInitializer[Channel] {
           override def initChannel(ch: Channel): Unit = {
             ch.pipeline.addLast(new Http2StreamFrameToHttpObjectCodec(true))
-            addHttp4sHandlers(ch.pipeline, config, httpApp, serviceErrorHandler, dispatcher)
+            addHttp4sHandlers(
+              ch.pipeline,
+              config,
+              httpApp,
+              serviceErrorHandler,
+              requestLineParseErrorHandler,
+              dispatcher)
           }
         })
       )
@@ -63,6 +71,7 @@ private object NettyPipelineHelpers {
       config: NegotiationHandler.Config,
       httpApp: WebSocketBuilder2[F] => HttpApp[F],
       serviceErrorHandler: ServiceErrorHandler[F],
+      requestLineParseErrorHandler: Throwable => F[Response[F]],
       dispatcher: Dispatcher[F]): Unit = void {
     // For HTTP/1.x pipelines the only backpressure we can exert is via the TCP
     // flow control mechanisms. That means we set auto-read to false so that we
@@ -72,7 +81,13 @@ private object NettyPipelineHelpers {
     pipeline.addLast(
       "http-codec",
       new HttpServerCodec(config.maxInitialLineLength, config.maxHeaderSize, config.maxChunkSize))
-    addHttp4sHandlers(pipeline, config, httpApp, serviceErrorHandler, dispatcher)
+    addHttp4sHandlers(
+      pipeline,
+      config,
+      httpApp,
+      serviceErrorHandler,
+      requestLineParseErrorHandler,
+      dispatcher)
   }
 
   private[this] def addHttp4sHandlers[F[_]: Async](
@@ -80,6 +95,7 @@ private object NettyPipelineHelpers {
       config: NegotiationHandler.Config,
       httpApp: WebSocketBuilder2[F] => HttpApp[F],
       serviceErrorHandler: ServiceErrorHandler[F],
+      requestLineParseErrorHandler: Throwable => F[Response[F]],
       dispatcher: Dispatcher[F]): Unit = void {
 
     if (config.idleTimeout.isFinite && config.idleTimeout.length > 0) {
@@ -100,7 +116,12 @@ private object NettyPipelineHelpers {
     pipeline.addLast(
       "http4s",
       Http4sNettyHandler
-        .websocket(httpApp, serviceErrorHandler, config.wsMaxFrameLength, dispatcher)
+        .websocket(
+          httpApp,
+          serviceErrorHandler,
+          requestLineParseErrorHandler,
+          config.wsMaxFrameLength,
+          dispatcher)
     )
   }
 }

--- a/server/src/main/scala/org/http4s/netty/server/NettyServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/netty/server/NettyServerBuilder.scala
@@ -50,6 +50,7 @@ import io.netty.incubator.channel.uring.IOUring
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup
 import io.netty.incubator.channel.uring.IOUringServerSocketChannel
 import org.http4s.HttpApp
+import org.http4s.Response
 import org.http4s.server.Server
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.defaults
@@ -78,7 +79,8 @@ final class NettyServerBuilder[F[_]] private (
     nettyChannelOptions: NettyChannelOptions,
     sslConfig: NettyServerBuilder.SslConfig,
     wsMaxFrameLength: Int,
-    wsCompression: Boolean
+    wsCompression: Boolean,
+    requestLineParseErrorHandler: Throwable => F[Response[F]]
 )(implicit F: Async[F]) {
   private val logger = org.log4s.getLogger
   type Self = NettyServerBuilder[F]
@@ -97,7 +99,8 @@ final class NettyServerBuilder[F[_]] private (
       nettyChannelOptions: NettyChannelOptions = nettyChannelOptions,
       sslConfig: NettyServerBuilder.SslConfig = sslConfig,
       wsMaxFrameLength: Int = wsMaxFrameLength,
-      wsCompression: Boolean = wsCompression
+      wsCompression: Boolean = wsCompression,
+      requestLineParseErrorHandler: Throwable => F[Response[F]] = requestLineParseErrorHandler
   ): NettyServerBuilder[F] =
     new NettyServerBuilder[F](
       httpApp,
@@ -113,7 +116,8 @@ final class NettyServerBuilder[F[_]] private (
       nettyChannelOptions,
       sslConfig,
       wsMaxFrameLength,
-      wsCompression
+      wsCompression,
+      requestLineParseErrorHandler
     )
 
   private def getEventLoop: EventLoopHolder[_ <: ServerChannel] =
@@ -192,6 +196,23 @@ final class NettyServerBuilder[F[_]] private (
   def withWebSocketCompression: Self = copy(wsCompression = true)
   def withoutWebSocketCompression: Self = copy(wsCompression = false)
 
+  /** An error handler which will run in cases where the server is unable to parse the "start-line"
+    * (http 2 name) or "request-line" (http 1.1 name). This is the first line of the request, e.g.
+    * "GET / HTTP/1.1".
+    *
+    * In this case, RFC 9112 (HTTP 2) says a 400 should be returned.
+    *
+    * This handler allows for configuring the behavior.
+    *
+    * @see
+    *   [[https://www.rfc-editor.org/rfc/rfc9112#section-2.2-9 RFC 9112]]
+    * @see
+    *   [[https://www.rfc-editor.org/rfc/rfc7230 RFC 7230]]
+    */
+  def withRequestLineParseErrorHandler(
+      handler: Throwable => F[Response[F]]
+  ): Self = copy(requestLineParseErrorHandler = handler)
+
   /** Configures the server with TLS, using the provided `SSLContext` and `SSLParameters`. We only
     * look at the needClientAuth and wantClientAuth boolean params. For more control use overload.
     */
@@ -267,6 +288,7 @@ final class NettyServerBuilder[F[_]] private (
                 config,
                 httpApp,
                 serviceErrorHandler,
+                requestLineParseErrorHandler,
                 dispatcher
               )
               pipeline.addLast("ssl", handler)
@@ -278,6 +300,7 @@ final class NettyServerBuilder[F[_]] private (
                 config,
                 httpApp,
                 serviceErrorHandler,
+                requestLineParseErrorHandler,
                 dispatcher
               )
               pipeline.addLast("h2-prior-knowledge-detection", h2PriorKnowledgeDetection)
@@ -360,8 +383,18 @@ object NettyServerBuilder {
       nettyChannelOptions = NettyChannelOptions.empty,
       sslConfig = NettyServerBuilder.NoSsl,
       wsMaxFrameLength = DefaultWSMaxFrameLength,
-      wsCompression = false
+      wsCompression = false,
+      requestLineParseErrorHandler = defaultRequestLineParseErrorHandler[F]
     )
+
+  private def defaultRequestLineParseErrorHandler[F[_]](implicit
+      F: Async[F]): Throwable => F[Response[F]] = { case _ =>
+    F.pure(
+      Response[F](
+        org.http4s.Status.BadRequest,
+        org.http4s.HttpVersion.`HTTP/1.1`,
+        org.http4s.Headers(org.http4s.headers.`Content-Length`.zero)))
+  }
 
   private sealed trait SslConfig {
     def toHandler(alloc: ByteBufAllocator): Option[SslHandler]

--- a/server/src/main/scala/org/http4s/netty/server/PriorKnowledgeDetectionHandler.scala
+++ b/server/src/main/scala/org/http4s/netty/server/PriorKnowledgeDetectionHandler.scala
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelPipeline
 import io.netty.handler.codec.ByteToMessageDecoder
 import io.netty.handler.codec.http2.Http2CodecUtil
 import org.http4s.HttpApp
+import org.http4s.Response
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.log4s.getLogger
@@ -36,6 +37,7 @@ private class PriorKnowledgeDetectionHandler[F[_]: Async](
     config: NegotiationHandler.Config,
     httpApp: WebSocketBuilder2[F] => HttpApp[F],
     serviceErrorHandler: ServiceErrorHandler[F],
+    requestLineParseErrorHandler: Throwable => F[Response[F]],
     dispatcher: Dispatcher[F]
 ) extends ByteToMessageDecoder {
 
@@ -69,6 +71,7 @@ private class PriorKnowledgeDetectionHandler[F[_]: Async](
       config,
       httpApp,
       serviceErrorHandler,
+      requestLineParseErrorHandler,
       dispatcher)
     pipeline.remove(this)
   }
@@ -80,6 +83,7 @@ private class PriorKnowledgeDetectionHandler[F[_]: Async](
       config,
       httpApp,
       serviceErrorHandler,
+      requestLineParseErrorHandler,
       dispatcher)
     pipeline.remove(this)
   }

--- a/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
+++ b/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
@@ -28,7 +28,9 @@ import fs2.interop.reactivestreams._
 import io.netty.buffer.Unpooled
 import io.netty.channel.Channel
 import io.netty.channel.ChannelFutureListener
+import io.netty.handler.codec.http.DefaultFullHttpResponse
 import io.netty.handler.codec.http.DefaultHttpResponse
+import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpHeaders
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http.HttpVersion
@@ -87,6 +89,23 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
             ).mapN(SecureSession.apply)
           }
       )
+
+  /** Convert an http4s Response to a simple Netty response without requiring a parsed Request. Used
+    * for error responses when request parsing fails
+    */
+  def toSimpleNettyResponse(httpResponse: Response[F]): Resource[F, DefaultHttpResponse] = {
+    val response = new DefaultFullHttpResponse(
+      HttpVersion.HTTP_1_1,
+      HttpResponseStatus.valueOf(httpResponse.status.code))
+    httpResponse.headers.foreach { h =>
+      val _ = response.headers().add(h.name.toString, h.value)
+    }
+    httpResponse.contentLength.foreach(len =>
+      response.headers().set(HttpHeaderNames.CONTENT_LENGTH, len))
+    if (!response.headers().contains(HttpHeaderNames.CONNECTION))
+      response.headers().set(HttpHeaderNames.CONNECTION, "close")
+    Resource.pure[F, DefaultHttpResponse](response)
+  }
 
   /** Create a Netty response from the result */
   def toNettyResponseWithWebsocket(

--- a/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
+++ b/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
@@ -102,8 +102,9 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
     }
     httpResponse.contentLength.foreach(len =>
       response.headers().set(HttpHeaderNames.CONTENT_LENGTH, len))
-    if (!response.headers().contains(HttpHeaderNames.CONNECTION))
-      response.headers().set(HttpHeaderNames.CONNECTION, "close")
+    if (!response.headers().contains(HttpHeaderNames.CONNECTION)) {
+      val _ = response.headers().set(HttpHeaderNames.CONNECTION, "close")
+    }
     Resource.pure[F, DefaultHttpResponse](response)
   }
 

--- a/server/src/test/scala/org/http4s/netty/server/InvalidRequestLineTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/InvalidRequestLineTest.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.netty.server
+
+import cats.effect.IO
+import cats.effect.Resource
+import munit.CatsEffectSuite
+import org.http4s.HttpRoutes
+import org.http4s.Response
+import org.http4s.Status
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import org.http4s.server.Server
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.PrintWriter
+import java.net.Socket
+import scala.concurrent.duration._
+
+class InvalidRequestLineTest extends CatsEffectSuite {
+
+  private val app = HttpRoutes
+    .of[IO] { case GET -> Root / "ok" =>
+      Ok("ok")
+    }
+    .orNotFound
+
+  private def serverResource: Resource[IO, Server] =
+    NettyServerBuilder[IO]
+      .withHttpApp(app)
+      .withNioTransport
+      .withIdleTimeout(5.seconds)
+      .withoutBanner
+      .bindAny()
+      .resource
+
+  private def sendRawRequest(server: Server, requestLine: String): IO[String] =
+    IO.blocking {
+      val addr = server.address
+      val socket = new Socket(addr.getHostName, addr.getPort)
+      try {
+        socket.setSoTimeout(5000)
+        val writer = new PrintWriter(socket.getOutputStream, true)
+        writer.print(s"$requestLine\r\nHost: localhost\r\n\r\n")
+        writer.flush()
+        val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
+        reader.readLine() // e.g. "HTTP/1.1 400 Bad Request"
+      } finally
+        socket.close()
+    }
+
+  test("invalid URI returns 400 by default") {
+    serverResource.use { server =>
+      sendRawRequest(server, "GET /hello?foo={ HTTP/1.1").map { statusLine =>
+        assert(statusLine.contains("400"), s"Expected 400 but got: $statusLine")
+      }
+    }
+  }
+
+  test("configurable requestLineParseErrorHandler") {
+    val customServer = NettyServerBuilder[IO]
+      .withHttpApp(app)
+      .withNioTransport
+      .withIdleTimeout(5.seconds)
+      .withoutBanner
+      .withRequestLineParseErrorHandler(_ => IO.pure(Response[IO](Status.NotFound)))
+      .bindAny()
+      .resource
+
+    customServer.use { server =>
+      sendRawRequest(server, "GET /hello?foo={ HTTP/1.1").map { statusLine =>
+        assert(statusLine.contains("404"), s"Expected 404 but got: $statusLine")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Right now an invalid http request line will result in a 500, but it should result in 400 instead.

This is the fix that I requested for ember here: https://github.com/http4s/http4s/issues/6931 but for http4s-netty.

I copied some of the code/comments from the PR there to try to keep some amount of consistency.