### PR TITLE
Don't ever allow double subscription to the netty publisher

### DIFF
--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -238,9 +238,8 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
                 // drainBody won the race and already consumed the publisher. We cannot
                 // serve a correct response. Emitting Stream.empty would silently produce
                 // a zero-byte body. This allows a handler to handle this separately.
-                Stream.raiseError[F](
-                  new IllegalStateException(
-                    "Request body publisher already consumed (drained by finalizer or compiled twice)"))
+                Stream.raiseError[F](new IllegalStateException(
+                  "Request body publisher already consumed (drained by finalizer or compiled twice)"))
             }
             .onFinalize(
               F.delay(void(state.compareAndSet(BodyState.Subscribed, BodyState.Finished))))
@@ -437,8 +436,9 @@ object NettyModelConversion {
 
   /** Return an action that will drain the channel stream in the case that it wasn't drained.
     *
-    * Uses `state` to atomically decide who owns the publisher: the route's body stream or this finalizer.
-    * Whoever loses must not call `subscribe` the underlying `HandlerPublisher` only accepts one subscriber.
+    * Uses `state` to atomically decide who owns the publisher: the route's body stream or this
+    * finalizer. Whoever loses must not call `subscribe` the underlying `HandlerPublisher` only
+    * accepts one subscriber.
     */
   private[netty] def drainBody[F[_]](
       c: Channel,

--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -40,7 +40,8 @@ import org.typelevel.ci.CIString
 import org.typelevel.vault.Vault
 
 import java.net.InetSocketAddress
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.Flow
+import java.util.concurrent.atomic.AtomicReference
 import javax.net.ssl.SSLEngine
 
 /** Helpers for converting http4s request/response objects to and from the netty model
@@ -222,18 +223,28 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
           ) // No cleanup action needed
         }
       case streamed: StreamedHttpMessage =>
-        val isDrained = new AtomicBoolean(false)
-        val subscribed = new AtomicBoolean(false)
+        val state = new AtomicReference[BodyState](BodyState.New)
+        val publisher = FlowAdapters.toFlowPublisher(streamed)
         val stream =
           Stream
-            .eval(F.delay(subscribed.set(true)))
-            .flatMap(_ =>
-              Stream
-                .fromPublisher[F](FlowAdapters.toFlowPublisher(streamed), 1))
-            .flatMap(c =>
-              Stream.chunk(Chunk.array(NettyModelConversion.bytebufToArray(c.content()))))
-            .onFinalize(F.delay(void(isDrained.compareAndSet(false, true))))
-        (stream, drainBody(_, stream, isDrained, subscribed))
+            .eval(F.delay(state.compareAndSet(BodyState.New, BodyState.Subscribed)))
+            .flatMap { won =>
+              if (won)
+                Stream
+                  .fromPublisher[F](publisher, 1)
+                  .flatMap(c =>
+                    Stream.chunk(Chunk.array(NettyModelConversion.bytebufToArray(c.content()))))
+              else
+                // drainBody won the race and already consumed the publisher. We cannot
+                // serve a correct response. Emitting Stream.empty would silently produce
+                // a zero-byte body. This allows a handler to handle this separately.
+                Stream.raiseError[F](
+                  new IllegalStateException(
+                    "Request body publisher already consumed (drained by finalizer or compiled twice)"))
+            }
+            .onFinalize(
+              F.delay(void(state.compareAndSet(BodyState.Subscribed, BodyState.Finished))))
+        (stream, drainBody(_, publisher, state))
       case _ => (Stream.empty.covary[F], _ => F.unit)
     }
 
@@ -417,33 +428,44 @@ object NettyModelConversion {
 
   val notAllowedWithBody: Set[Method] = Set(Method.HEAD, Method.GET)
 
+  private[netty] sealed trait BodyState
+  private[netty] object BodyState {
+    case object New extends BodyState
+    case object Subscribed extends BodyState
+    case object Finished extends BodyState
+  }
+
   /** Return an action that will drain the channel stream in the case that it wasn't drained.
+    *
+    * Uses `state` to atomically decide who owns the publisher: the route's body stream or this finalizer.
+    * Whoever loses must not call `subscribe` the underlying `HandlerPublisher` only accepts one subscriber.
     */
   private[netty] def drainBody[F[_]](
       c: Channel,
-      f: Stream[F, Byte],
-      isDrained: AtomicBoolean,
-      subscribed: AtomicBoolean)(implicit F: Async[F]): F[Unit] =
+      publisher: Flow.Publisher[HttpContent],
+      state: AtomicReference[BodyState])(implicit F: Async[F]): F[Unit] =
     F.delay {
-      if (isDrained.compareAndSet(false, true)) {
-        if (subscribed.get()) {
-          // The stream was already subscribed to (body partially consumed).
-          // HandlerPublisher only supports one subscriber, so we cannot
-          // re-subscribe to drain. Close the connection instead. The
-          // remaining request bytes would corrupt the next request anyway.
-          logger.info("Request body not fully drained but already subscribed. Closing connection")
-          F.delay(c.close()).void
-        } else if (c.isOpen) {
-          logger.info("Response body not drained to completion. Draining and closing connection")
-          // Drain the stream regardless. Some bytebufs often
-          // Remain in the buffers. Draining them solves this issue
-          F.delay(c.close()).liftToF >> f.compile.drain
-        } else
-          // Drain anyway, don't close the channel
-          f.compile.drain
-      } else {
-        F.unit
-      }
+      if (state.compareAndSet(BodyState.New, BodyState.Finished)) {
+        logger.info("Response body not drained to completion. Draining and closing connection")
+        // We own the publisher, so we drain via a fresh subscription.
+        val drain = Stream.fromPublisher[F](publisher, 1).compile.drain
+        if (c.isOpen)
+          F.delay(c.close()).liftToF >> drain
+        else
+          drain
+      } else
+        state.get() match {
+          case BodyState.Subscribed =>
+            // Route is mid-flight on the body. We cannot re-subscribe, and the remaining
+            // request bytes would corrupt the next request, so close the connection.
+            logger.info("Request body not fully drained but already subscribed. Closing connection")
+            F.delay(c.close()).void
+          case BodyState.Finished =>
+            F.unit
+          case BodyState.New =>
+            // Unreachable: CAS New→Finished failed, so state is no longer New.
+            F.unit
+        }
     }.flatMap(identity)
 
   private[netty] def toHeaders(headers: HttpHeaders): Headers = {

--- a/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
@@ -17,6 +17,7 @@
 package org.http4s.netty.server
 
 import cats.effect.IO
+import cats.effect.kernel.Outcome
 import io.netty.buffer.Unpooled
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http.DefaultHttpContent
@@ -31,6 +32,7 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration._
 
 /** When a request body stream is actively being consumed and the request is released, `drainBody`
@@ -101,6 +103,134 @@ class DrainBodyDoubleSubscribeTest extends CatsEffectSuite {
                 )
               }
           }
+      }
+    }
+  }
+
+  /** Like SingleSubscriberPublisher, but counts every `subscribe` call so a test can assert it
+    * was only invoked once even when no `onError` propagates back to the caller.
+    */
+  private class CountingSingleSubscriberPublisher extends Publisher[HttpContent] {
+    val subscribeCount = new AtomicInteger(0)
+    private val hasSubscriber = new AtomicBoolean(false)
+
+    override def subscribe(s: Subscriber[_ >: HttpContent]): Unit = {
+      subscribeCount.incrementAndGet()
+      if (!hasSubscriber.compareAndSet(false, true)) {
+        s.onSubscribe(new Subscription {
+          override def request(n: Long): Unit = ()
+          override def cancel(): Unit = ()
+        })
+        s.onError(new IllegalStateException("This publisher only supports one subscriber"))
+      } else {
+        s.onSubscribe(new Subscription {
+          private val emitted = new AtomicBoolean(false)
+          override def request(n: Long): Unit =
+            if (emitted.compareAndSet(false, true)) {
+              val content =
+                new DefaultHttpContent(Unpooled.wrappedBuffer(Array.fill(64)(42.toByte)))
+              s.onNext(content)
+              s.onComplete()
+            }
+          override def cancel(): Unit = ()
+        })
+      }
+    }
+  }
+
+  // Helper to see if any of the exceptions are the in the stack.
+  private def isDoubleSubscribeError(t: Throwable): Boolean = {
+    def loop(x: Throwable): Boolean =
+      x != null &&
+        ((x.getMessage != null && x.getMessage.contains("only supports one subscriber"))
+          || loop(x.getCause))
+    loop(t)
+  }
+
+  /** Deterministic racing using deferred and fibers.
+    *
+    * Thread A (route handler) starts compiling the body but is paused before evaluating the body
+    * stream. Thread B (the request Resource finalizer) runs drainBody while A is paused.
+    * When A is unpaused it cannot also subscribe as that would violate the requirements of a single subscriber.
+    *
+    * We use a `Deferred` to make the interleaving deterministic. Under load the same interleaving
+    * occurs naturally, just less reliably.
+    */
+  test("drainBody and body compile must not double-subscribe the request publisher") {
+    val publisher = new CountingSingleSubscriberPublisher
+    val channel = new EmbeddedChannel()
+    val request = new DefaultStreamedHttpRequest(
+      HttpVersion.HTTP_1_1,
+      HttpMethod.PUT,
+      "/test",
+      publisher
+    )
+    val conversion = new NettyModelConversion[IO]
+
+    conversion.fromNettyRequest(channel, request).allocated.flatMap { case (req, release) =>
+      IO.deferred[Unit].flatMap { gate =>
+        for {
+          // Start the route's body consumer but block it before any Stream step evaluates.
+          // This models the scheduler not yet having run the first IO step of the body compile.
+          bodyFiber <- (gate.get *> req.body.compile.drain).attempt.start
+          // While the route fiber is parked, run release. drainBody observes subscribed=false
+          // and calls f.compile.drain, which subscribes to the publisher.
+          releaseResult <- release.attempt
+          // Unblock the route fiber. It now runs the body stream, which used to call subscribe AGAIN.
+          _ <- gate.complete(())
+          bodyOutcome <- bodyFiber.join.timeout(5.seconds)
+          bodyResult <- bodyOutcome match {
+            case Outcome.Succeeded(io) => io
+            case Outcome.Errored(e) => IO.pure(Left(e))
+            case Outcome.Canceled() => IO.pure(Left(new RuntimeException("body fiber cancelled")))
+          }
+        } yield {
+          val errs = List(bodyResult, releaseResult).collect {
+            case Left(e) if isDoubleSubscribeError(e) => e
+          }
+          assert(
+            errs.isEmpty && publisher.subscribeCount.get() == 1,
+            s"Double subscribe detected (subscribeCount=${publisher.subscribeCount.get()}). " +
+              s"bodyResult=$bodyResult releaseResult=$releaseResult"
+          )
+        }
+      }
+    }
+  }
+
+  /** If route code compiles the body more than once, the second compile must fail cleanly
+    * (state-machine raise) rather than corrupt the underlying single-subscriber publisher by
+    * calling subscribe a second time.
+    */
+  test("compiling req.body twice fails cleanly without double-subscribing the publisher") {
+    val publisher = new CountingSingleSubscriberPublisher
+    val channel = new EmbeddedChannel()
+    val request = new DefaultStreamedHttpRequest(
+      HttpVersion.HTTP_1_1,
+      HttpMethod.PUT,
+      "/test",
+      publisher
+    )
+    val conversion = new NettyModelConversion[IO]
+
+    conversion.fromNettyRequest(channel, request).allocated.flatMap { case (req, release) =>
+      for {
+        firstResult <- req.body.compile.drain.attempt
+        secondResult <- req.body.compile.drain.attempt
+        releaseResult <- release.attempt
+      } yield {
+        assert(firstResult.isRight, s"first compile should succeed, got: $firstResult")
+        assert(secondResult.isLeft, s"second compile should fail, got: $secondResult")
+        val secondErr = secondResult.swap.toOption.get
+        assert(
+          !isDoubleSubscribeError(secondErr),
+          s"second compile must NOT surface a publisher double-subscribe error, got: $secondErr"
+        )
+        assert(releaseResult.isRight, s"release should not throw, got: $releaseResult")
+        assert(
+          publisher.subscribeCount.get() == 1,
+          s"publisher must be subscribed exactly once, got: ${publisher.subscribeCount.get()}"
+        )
       }
     }
   }

--- a/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
+++ b/server/src/test/scala/org/http4s/netty/server/DrainBodyDoubleSubscribeTest.scala
@@ -107,8 +107,8 @@ class DrainBodyDoubleSubscribeTest extends CatsEffectSuite {
     }
   }
 
-  /** Like SingleSubscriberPublisher, but counts every `subscribe` call so a test can assert it
-    * was only invoked once even when no `onError` propagates back to the caller.
+  /** Like SingleSubscriberPublisher, but counts every `subscribe` call so a test can assert it was
+    * only invoked once even when no `onError` propagates back to the caller.
     */
   private class CountingSingleSubscriberPublisher extends Publisher[HttpContent] {
     val subscribeCount = new AtomicInteger(0)
@@ -150,8 +150,9 @@ class DrainBodyDoubleSubscribeTest extends CatsEffectSuite {
   /** Deterministic racing using deferred and fibers.
     *
     * Thread A (route handler) starts compiling the body but is paused before evaluating the body
-    * stream. Thread B (the request Resource finalizer) runs drainBody while A is paused.
-    * When A is unpaused it cannot also subscribe as that would violate the requirements of a single subscriber.
+    * stream. Thread B (the request Resource finalizer) runs drainBody while A is paused. When A is
+    * unpaused it cannot also subscribe as that would violate the requirements of a single
+    * subscriber.
     *
     * We use a `Deferred` to make the interleaving deterministic. Under load the same interleaving
     * occurs naturally, just less reliably.


### PR DESCRIPTION
I found out that my previous design with 2 atomic booleans had an issue in a race condition. This adds a test that fails on 0.7 and is now fixed.

This will also raise the same error in the case of double consumption of the body instead of erroring with a double subscriber error.