### PR TITLE
Make modelConversion.fromNettyResponse sync on the event loop

### DIFF
--- a/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
@@ -39,11 +39,7 @@ import org.http4s.netty.client.Http4sHandler.logger
 import java.io.IOException
 import java.nio.channels.ClosedChannelException
 import java.util.concurrent.CancellationException
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import scala.concurrent.TimeoutException
-import scala.util.Failure
-import scala.util.Success
 
 private[netty] class Http4sHandler[F[_]](dispatcher: Dispatcher[F])(implicit F: Async[F])
     extends ChannelInboundHandlerAdapter {
@@ -58,10 +54,6 @@ private[netty] class Http4sHandler[F[_]](dispatcher: Dispatcher[F])(implicit F: 
   //     That means calls to ctx.read(), and ct.write(..), would have to be trampolined otherwise.
   //  2. We get serialization of execution: the EventLoop is a serial execution queue so
   //     we can rest easy knowing that no two events will be executed in parallel.
-  private var eventLoopContext: ExecutionContext = _
-
-  private var pending: Future[Unit] = Future.unit
-  private var inFlight: Option[Promise] = None
 
   private def write2(request: Request[F], channel: Channel, key: Key): F[Unit] = {
     import io.netty.handler.codec.http2._
@@ -132,31 +124,13 @@ private[netty] class Http4sHandler[F[_]](dispatcher: Dispatcher[F])(implicit F: 
   override def isSharable: Boolean = false
 
   override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = void {
-    implicit val ec: ExecutionContext = eventLoopContext
-
     msg match {
       case h: HttpResponse =>
-        val responseResourceF = modelConversion.fromNettyResponse(h, ctx.channel())
-        val result = dispatcher.unsafeToFuture(responseResourceF)
-
         if (promises.nonEmpty) {
           val promise = promises.dequeue()
-          inFlight = Some(promise)
           logger.trace("dequeuing promise")
-          pending = pending.flatMap { _ =>
-            result.transform {
-              case Failure(exception) =>
-                logger.trace("handling promise failure")
-                promise(Left(exception))
-                inFlight = None
-                Failure(exception)
-              case Success(res) =>
-                logger.trace("handling promise success")
-                promise(Right(res))
-                inFlight = None
-                Success(())
-            }
-          }
+          val result = modelConversion.fromNettyResponsePure(h, ctx.channel())
+          promise(result)
         }
       case x: Http2PingFrame =>
         if (!x.ack()) {
@@ -183,12 +157,6 @@ private[netty] class Http4sHandler[F[_]](dispatcher: Dispatcher[F])(implicit F: 
     }
   }
 
-  override def handlerAdded(ctx: ChannelHandlerContext): Unit =
-    if (eventLoopContext == null) void {
-      // Initialize our ExecutionContext
-      eventLoopContext = ExecutionContext.fromExecutor(ctx.channel.eventLoop)
-    }
-
   override def channelInactive(ctx: ChannelHandlerContext): Unit =
     onException(ctx.channel(), new ClosedChannelException())
 
@@ -206,13 +174,9 @@ private[netty] class Http4sHandler[F[_]](dispatcher: Dispatcher[F])(implicit F: 
     }
 
   private def onException(channel: Channel, e: Throwable): Unit = void {
-    implicit val ec: ExecutionContext = eventLoopContext
-
-    val allPromises =
-      (inFlight.toList ++ promises.dequeueAll(_ => true)).map(promise => Future(promise(Left(e))))
+    val allPromises = promises.dequeueAll(_ => true)
     logger.trace(s"onException: dequeueAll(${allPromises.size})")
-    pending = pending.flatMap(_ => Future.sequence(allPromises).map(_ => ()))
-    inFlight = None
+    allPromises.foreach(_(Left(e)))
 
     channel.close()
   }

--- a/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sHandler.scala
@@ -129,7 +129,7 @@ private[netty] class Http4sHandler[F[_]](dispatcher: Dispatcher[F])(implicit F: 
         if (promises.nonEmpty) {
           val promise = promises.dequeue()
           logger.trace("dequeuing promise")
-          val result = modelConversion.fromNettyResponsePure(h, ctx.channel())
+          val result = modelConversion.fromNettyResponse(h, ctx.channel())
           promise(result)
         }
       case x: Http2PingFrame =>

--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -95,14 +95,7 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
     }
   }
 
-  def fromNettyResponse(response: HttpResponse, channel: Channel): F[Resource[F, Response[F]]] =
-    F.fromEither(fromNettyResponsePure(response, channel))
-
-  /** Pure variant of [[fromNettyResponse]] that avoids an async round-trip through the effect
-    * runtime. Used by the client handler to resolve the response promise synchronously on the Netty
-    * event loop, eliminating a race between channelRead and channelInactive.
-    */
-  def fromNettyResponsePure(
+  def fromNettyResponse(
       response: HttpResponse,
       channel: Channel): Either[Throwable, Resource[F, Response[F]]] = {
     logger.trace(s"converting response: $response")

--- a/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
+++ b/core/src/main/scala/org/http4s/netty/NettyModelConversion.scala
@@ -95,10 +95,19 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
     }
   }
 
-  def fromNettyResponse(response: HttpResponse, channel: Channel): F[Resource[F, Response[F]]] = {
+  def fromNettyResponse(response: HttpResponse, channel: Channel): F[Resource[F, Response[F]]] =
+    F.fromEither(fromNettyResponsePure(response, channel))
+
+  /** Pure variant of [[fromNettyResponse]] that avoids an async round-trip through the effect
+    * runtime. Used by the client handler to resolve the response promise synchronously on the Netty
+    * event loop, eliminating a race between channelRead and channelInactive.
+    */
+  def fromNettyResponsePure(
+      response: HttpResponse,
+      channel: Channel): Either[Throwable, Resource[F, Response[F]]] = {
     logger.trace(s"converting response: $response")
     val (body, drain) = convertHttpBody(response)
-    val res = for {
+    (for {
       status <- Status.fromInt(response.status().code())
       version <- HV.fromString(response.protocolVersion().text())
     } yield Response(
@@ -106,9 +115,7 @@ private[netty] class NettyModelConversion[F[_]](implicit F: Async[F]) {
       version,
       toHeaders(response.headers()),
       body
-    )
-
-    F.fromEither(res).tupleRight(drain).map(t => Resource.make(F.pure(t._1))(_ => t._2(channel)))
+    )).map(resp => Resource.make(F.pure(resp))(_ => drain(channel)))
   }
 
   def toNettyHeaders(headers: Headers): HttpHeaders = {


### PR DESCRIPTION
Make fromNettyResponse sync to simplify error handling logic around ChannelClosed. This should fix the
```
==> X org.http4s.netty.server.NettyClientServerTest.Unhandled service exceptions will be turned into a 500 response 0.043s java.nio.channels.ClosedChannelException: null
```
errors seen in CI.

The operation fromNettyResponse should be cheap enough that it doesn't really matter that it is executed on the event loop.

As discussed here: https://github.com/http4s/http4s-netty/pull/967#issuecomment-4779020572

Let me know if you would prefer a different kind of fix :pray: 