### PR TITLE
Bytebuf leak fix

### DIFF
--- a/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
+++ b/server/src/main/scala/org/http4s/netty/server/ServerNettyModelConversion.scala
@@ -171,6 +171,7 @@ private[server] final class ServerNettyModelConversion[F[_]](implicit F: Async[F
                       channel.writeAndFlush(closeFrame).addListener(ChannelFutureListener.CLOSE))
                     .void
                 } else {
+                  closeFrame.release()
                   Sync[F].delay(channel.close()).void
                 }
             } yield modified


### PR DESCRIPTION
We create the frame even if we don't write it.
Make sure to release.

```SEVERE: LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records: 
Created at:
	io.netty.buffer.UnpooledByteBufAllocator.newDirectBuffer(UnpooledByteBufAllocator.java:97)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:168)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:159)
	io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:96)
	io.netty.handler.codec.http.websocketx.CloseWebSocketFrame.newBinaryData(CloseWebSocketFrame.java:139)
	io.netty.handler.codec.http.websocketx.CloseWebSocketFrame.<init>(CloseWebSocketFrame.java:131)
	io.netty.handler.codec.http.websocketx.CloseWebSocketFrame.<init>(CloseWebSocketFrame.java:111)
	io.netty.handler.codec.http.websocketx.CloseWebSocketFrame.<init>(CloseWebSocketFrame.java:82)
	io.netty.handler.codec.http.websocketx.CloseWebSocketFrame.<init>(CloseWebSocketFrame.java:45)
	org.http4s.netty.server.ServerNettyModelConversion.$anonfun$toWSResponse$8(ServerNettyModelConversion.scala:192)
	fs2.Stream.$anonfun$flatMap$1(Stream.scala:1295)
	fs2.Pull$FlatMapR$1.unconsed(Pull.scala:1042)
	fs2.Pull$FlatMapR$1.out(Pull.scala:1078)
	fs2.Pull$.$anonfun$compile$24(Pull.scala:1236)
	fs2.Pull$.$anonfun$compile$2(Pull.scala:952)
	cats.effect.IOFiber.succeeded(IOFiber.scala:1237)
	cats.effect.IOFiber.runLoop(IOFiber.scala:289)
	cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1405)
	cats.effect.IOFiber.run(IOFiber.scala:123)
	cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:935)
```