### PR TITLE
Apply max age to idle connections too

### DIFF
--- a/client/src/main/scala/org/http4s/netty/client/Http4sChannelPoolMap.scala
+++ b/client/src/main/scala/org/http4s/netty/client/Http4sChannelPoolMap.scala
@@ -27,7 +27,9 @@ import fs2.io.net.tls.TLSParameters
 import io.netty.bootstrap.Bootstrap
 import io.netty.channel.Channel
 import io.netty.channel.ChannelFuture
+import io.netty.channel.ChannelHandler
 import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.ChannelInitializer
 import io.netty.channel.ChannelPipeline
 import io.netty.channel.ChannelPromise
@@ -43,6 +45,8 @@ import io.netty.handler.codec.http2.Http2StreamChannelBootstrap
 import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec
 import io.netty.handler.ssl.ApplicationProtocolNames
 import io.netty.handler.ssl.SslHandler
+import io.netty.handler.timeout.IdleState
+import io.netty.handler.timeout.IdleStateEvent
 import io.netty.handler.timeout.IdleStateHandler
 import io.netty.util.AttributeKey
 import io.netty.util.concurrent.Future
@@ -198,17 +202,48 @@ private[client] class Http4sChannelPoolMap[F[_]](
       key: Key,
       config: Http4sChannelPoolMap.Config
   ) extends AbstractChannelPoolHandler {
-    override def channelAcquired(ch: Channel): Unit =
+    override def channelAcquired(ch: Channel): Unit = void {
       logger.trace(s"Connected to $ch for ${key}")
+      ch.attr(Http4sChannelPoolMap.CheckedOut).set(java.lang.Boolean.TRUE)
+      val pipeline = ch.pipeline()
+      if (pipeline.get(Http4sChannelPoolMap.MaxAgeCloserHandlerName) != null)
+        void(pipeline.remove(Http4sChannelPoolMap.MaxAgeCloserHandlerName))
+      if (pipeline.get(Http4sChannelPoolMap.MaxAgeIdleHandlerName) != null)
+        void(pipeline.remove(Http4sChannelPoolMap.MaxAgeIdleHandlerName))
+    }
 
     override def channelCreated(ch: Channel): Unit = void {
       logger.trace(s"Created $ch for ${key}")
       ch.attr(Http4sChannelPoolMap.CreatedAt).set(System.nanoTime())
+      ch.attr(Http4sChannelPoolMap.CheckedOut).set(java.lang.Boolean.TRUE)
       buildPipeline(ch)
     }
 
-    override def channelReleased(ch: Channel): Unit =
+    override def channelReleased(ch: Channel): Unit = void {
       logger.trace(s"Releasing $ch ${key}")
+      ch.attr(Http4sChannelPoolMap.CheckedOut).set(java.lang.Boolean.FALSE)
+      if (config.maxConnectionAge.isFinite) {
+        val createdAt = ch.attr(Http4sChannelPoolMap.CreatedAt).get()
+        if (createdAt != null) {
+          val elapsedNanos = System.nanoTime() - createdAt
+          val remainingNanos = config.maxConnectionAge.toNanos - elapsedNanos
+          val remainingMillis = TimeUnit.NANOSECONDS.toMillis(remainingNanos)
+          if (remainingMillis <= 0) {
+            logger.trace(s"Closing $ch immediately — max connection age already exceeded")
+            void(ch.close())
+          } else {
+            val pipeline = ch.pipeline()
+            pipeline.addFirst(
+              Http4sChannelPoolMap.MaxAgeCloserHandlerName,
+              Http4sChannelPoolMap.MaxAgeCloserHandler)
+            void(
+              pipeline.addFirst(
+                Http4sChannelPoolMap.MaxAgeIdleHandlerName,
+                new IdleStateHandler(0, 0, remainingMillis, TimeUnit.MILLISECONDS)))
+          }
+        }
+      }
+    }
 
     private def buildPipeline(channel: Channel) = {
       logger.trace(s"building pipeline for ${key}")
@@ -276,8 +311,30 @@ private[client] class Http4sChannelPoolMap[F[_]](
 }
 
 private[client] object Http4sChannelPoolMap {
+  private val logger = org.log4s.getLogger
+
   private val CreatedAt: AttributeKey[java.lang.Long] =
     AttributeKey.valueOf("http4s.channel.createdAt")
+  private val CheckedOut: AttributeKey[java.lang.Boolean] =
+    AttributeKey.valueOf("http4s.channel.checkedOut")
+
+  private val MaxAgeIdleHandlerName = "max-age-idle"
+  private val MaxAgeCloserHandlerName = "max-age-closer"
+
+  @ChannelHandler.Sharable
+  private object MaxAgeCloserHandler extends ChannelInboundHandlerAdapter {
+    override def userEventTriggered(ctx: ChannelHandlerContext, evt: AnyRef): Unit =
+      evt match {
+        case e: IdleStateEvent if e.state() == IdleState.ALL_IDLE =>
+          val ch = ctx.channel()
+          val checkedOut = ch.attr(CheckedOut).get()
+          if (checkedOut == null || !checkedOut) {
+            logger.trace(s"Closing connection $ch due to max connection age while idle in pool")
+            void(ch.close())
+          }
+        case _ => super.userEventTriggered(ctx, evt)
+      }
+  }
 
   private def connectionAgeHealthChecker(maxConnectionAge: Duration): ChannelHealthChecker =
     if (!maxConnectionAge.isFinite) ChannelHealthChecker.ACTIVE

--- a/client/src/test/scala/org/http4s/netty/client/NettyClientConnectionAgeTest.scala
+++ b/client/src/test/scala/org/http4s/netty/client/NettyClientConnectionAgeTest.scala
@@ -17,16 +17,22 @@
 package org.http4s.netty.client
 
 import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.kernel.Deferred
+import cats.syntax.all._
 import com.comcast.ip4s._
 import munit.catseffect.IOFixture
 import org.http4s.HttpRoutes
 import org.http4s.Request
+import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.dsl.io._
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits._
 import org.http4s.server.Server
 
+import java.net.ServerSocket
+import java.nio.charset.StandardCharsets
 import scala.concurrent.duration._
 
 class NettyClientConnectionAgeTest extends IOSuite {
@@ -77,5 +83,57 @@ class NettyClientConnectionAgeTest extends IOSuite {
     for {
       r <- c.expect[String](req)
     } yield assertEquals(r, "slow")
+  }
+
+  test("idle connection in pool is proactively closed after max age expires") {
+    val httpResponse =
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok"
+    // Use a raw TCP server so we can observe when the client closes the connection
+    // without triggering any pool acquire/release.
+    val serverSocketR =
+      Resource.make(IO.blocking(new ServerSocket(0)))(ss => IO.blocking(ss.close()))
+    val clientR = NettyClientBuilder[IO].withMaxConnectionAge(2.seconds).resource
+
+    (serverSocketR, clientR, Deferred[IO, Unit].toResource).tupled.use {
+      case (serverSocket, client, clientClosed) =>
+        val port = serverSocket.getLocalPort
+        // Accept one connection and serve a minimal HTTP response, then watch for close
+        Resource
+          .make(IO.blocking(serverSocket.accept()))(socket => IO.blocking(socket.close()))
+          .use { socket =>
+            val in = socket.getInputStream
+            val out = socket.getOutputStream
+            // Read the HTTP request (consume until empty line)
+
+            for {
+              _ <- IO.blocking(in.read(new Array[Byte](4096)))
+              // Send a minimal HTTP/1.1 response
+              _ <- IO.blocking(out.write(httpResponse.getBytes(StandardCharsets.US_ASCII)))
+              _ <- IO.blocking(out.flush())
+              // Now wait for the client to close the connection
+              // read() returns -1 when the peer closes
+              _ <- IO.blocking(in.read()).iterateUntil(_ == -1)
+              // only goes here if in.read returned -1
+              _ <- clientClosed.complete(())
+            } yield ()
+          }
+          .background
+          .use { _ =>
+            for {
+              _ <- client.expect[String](
+                Request[IO](uri = Uri.unsafeFromString(s"http://localhost:$port/test"))
+              )
+              // Connection is idle in the pool. Wait for max age (2s) + buffer.
+              // If proactive eviction works, the client closes the connection during
+              // this sleep — without any acquire to trigger the health check.
+              result <- clientClosed.get
+                .as(true)
+                .timeoutTo(5.seconds, IO.pure(false))
+            } yield assert(
+              result,
+              "expected idle connection to be closed proactively after max age")
+
+          }
+    }
   }
 }


### PR DESCRIPTION
Previously, max age of connections were only checked on acquire/release, meaning an idle connection in the pool were allowed to exceed its max age.

This PR adds an idle timeout (equal to the remaining time left) to each connection being released to the pool to ensure that even idle connections are reaped.

Note that I didn't disable the healthchecker for releasing connections back to the pool, though it arguably does the same thing as this idle logic. We could disable it if you prefer or leave it just to keep it symmetrical.